### PR TITLE
Add dispatch support for menu synchronization and modal handling

### DIFF
--- a/NSAlert+Eau.m
+++ b/NSAlert+Eau.m
@@ -7,6 +7,7 @@
 
 #import <AppKit/AppKit.h>
 #import <objc/runtime.h>
+#import <dispatch/dispatch.h>
 #import "NSAlert+Eau.h"
 #import "Eau.h"
 #import "AppearanceMetrics.h"
@@ -1254,17 +1255,11 @@ static void setKeyEquivalent(NSButton *button)
 
     if (![NSThread isMainThread])
     {
-        [self performSelectorOnMainThread: _cmd withObject: nil waitUntilDone: YES];
-        @try {
-            NSNumber *resultValue = [self valueForKey: @"_result"];
-            if (resultValue != nil)
-            {
-                return [resultValue integerValue];
-            }
-        } @catch (NSException *exception) {
-            // Ignore and fall through
-        }
-        return NSAlertErrorReturn;
+        __block NSInteger result;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            result = [self eau_runModal];
+        });
+        return result;
     }
     
     // Call _setupPanel - this invokes the Eau custom setup since methods were swizzled

--- a/NSApplication+Eau.m
+++ b/NSApplication+Eau.m
@@ -10,6 +10,7 @@
 
 #import <AppKit/AppKit.h>
 #import <objc/runtime.h>
+#import <dispatch/dispatch.h>
 
 @implementation NSApplication (EauApplication)
 

--- a/NSButtonCell+Eau.m
+++ b/NSButtonCell+Eau.m
@@ -16,6 +16,7 @@
 #import "Eau+Button.h"
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
+#import <dispatch/dispatch.h>
 #import <objc/runtime.h>
 
 // Prevent the specific "return" images from ever being drawn by intercepting common draw methods.
@@ -401,7 +402,9 @@ static NSMutableSet *returnImageCells = nil;
     // Only schedule ONE delayed attempt to prevent loops
     EAULOG(@"NSButtonCell+Eau: Scheduling single delayed attempt for button cell %p", self);
     @try {
-      [self performSelector:@selector(finalAttemptSetAsDefaultButton) withObject:nil afterDelay:1.0];
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self finalAttemptSetAsDefaultButton];
+      });
     }
     @catch (NSException *performException) {
       EAULOG(@"NSButtonCell+Eau: ERROR scheduling delayed attempt for cell %p: %@", self, performException);


### PR DESCRIPTION
- Introduced dispatch_async and dispatch_sync for main thread operations in Eau.m and NSAlert+Eau.m to improve responsiveness.
- Added notification observer for window activation in Eau.m to sync menus with active windows.
- Updated NSButtonCell+Eau.m to use dispatch_after for delayed button cell actions.