### PR TITLE
Fix signed/unsigned comparison warnings (and a count==0 underflow) in tab/segmented drawing

### DIFF
--- a/Eau+TabView.m
+++ b/Eau+TabView.m
@@ -18,7 +18,7 @@
 {
   NSGraphicsContext *ctxt = GSCurrentContext();
   const NSUInteger howMany = [items count];
-  int i;
+  NSUInteger i;
   int previousState = 0;
   const NSTabViewType type = [(NSTabView *)view tabViewType];
   const NSRect bounds = [view bounds];

--- a/NSSegmentedCell+Eau.m
+++ b/NSSegmentedCell+Eau.m
@@ -44,7 +44,7 @@
   NSBezierPath* linesPath = [NSBezierPath bezierPath];
   [linesPath setLineWidth: 1];
   CGFloat offsetX = 0;
-  for (i = 0; i < count-1;i++)
+  for (i = 0; i < (NSInteger)count - 1; i++)
     {
       frame.size.width = [xself widthForSegment: i];
       if(frame.size.width == 0.0)


### PR DESCRIPTION
## What

Fixes the 5 `-Wsign-compare` warnings in the tab and segmented-cell drawing paths:

- `Eau+TabView.m` — the drawing loop index is changed from `int` to `NSUInteger` (it indexes the `items` array via `objectAtIndex:`, which takes `NSUInteger`), so `i < howMany` / `i == howMany - 1` no longer mix signs.
- `NSSegmentedCell+Eau.m` — the loop now compares the `NSInteger` index against `(NSInteger)count - 1` rather than the unsigned `count - 1`.

## Why

Two reasons:

1. **Warning hygiene** — the theme builds warning-free on the default flags, but `-Wsign-compare` (not on by default) flags these. Keeping it clean under that flag avoids masking a real one later.
2. **A latent bug in the segmented cell** — `count` is `NSUInteger`, so when `segmentCount == 0` the old `count - 1` wraps to `SIZE_MAX` and the loop body runs once against a non-existent segment. Comparing against `(NSInteger)count - 1` makes the empty case correctly skip the loop.

No behaviour change on the default build; verified with:

```
gmake ADDITIONAL_OBJCFLAGS="-fobjc-arc -fobjc-arc-exceptions -Wsign-compare -Wall"
```

→ 0 warnings, 0 errors (was 5 sign-compare warnings).

Closes #34
