### PR TITLE
Fix NSSearchField infinite-recursion crash (SIGSEGV) on first draw

### DIFF
--- a/NSSearchFieldCell+Eau.m
+++ b/NSSearchFieldCell+Eau.m
@@ -80,14 +80,21 @@
 
 - (void) EAUdrawWithFrame: (NSRect)cellFrame inView: (NSView*)controlView
 {
-  // TS: unused
-  // NSRect frame = cellFrame;
-  [super drawWithFrame: [self searchTextRectForBounds: cellFrame ]
-	 inView: controlView];
- [_search_button_cell drawWithFrame: [self searchButtonRectForBounds: cellFrame] inView: controlView];
+  // Draw the Eau search bezel + the text interior directly. We must NOT call
+  // [super drawWithFrame:] here: Eau's theme-override mechanism re-dispatches
+  // drawWithFrame: dynamically back into THIS method (super does not escape the
+  // override), so the original code recursed until the stack overflowed and the
+  // app crashed (SIGSEGV) on first draw of any NSSearchField.
+  // Calling the EAU* helpers directly reproduces what NSCell's drawWithFrame:
+  // would have done (border/background + interior) without re-dispatching.
+  [self _EAUdrawBorderAndBackgroundWithFrame: cellFrame inView: controlView];
+  [self EAUdrawInteriorWithFrame: cellFrame inView: controlView];
+
+  [_search_button_cell drawWithFrame: [self searchButtonRectForBounds: cellFrame]
+			      inView: controlView];
   if ([[self stringValue] length] > 0)
     [_cancel_button_cell drawWithFrame: [self cancelButtonRectForBounds: cellFrame]
-		       inView: controlView];
+			        inView: controlView];
 }
 
 /* This method put the "x" cell inside the Text cell */


### PR DESCRIPTION
## What

Fixes the SIGSEGV that crashes any app with an `NSSearchField` on first draw under Eau. `-[NSSearchFieldCell(EauTheme) EAUdrawWithFrame:inView:]` now draws the Eau bezel + interior via the `EAU*` helpers (`_EAUdrawBorderAndBackgroundWithFrame:inView:` + `EAUdrawInteriorWithFrame:inView:`) instead of calling `[super drawWithFrame:]`.

## Why

Eau installs its search-field drawing through the GSTheme override mechanism (`_overrideNSSearchFieldCellMethod_drawWithFrame:`), which re-dispatches `drawWithFrame:` dynamically back into the same override — `super` does not escape it. So `EAUdrawWithFrame:` → `[super drawWithFrame:]` → `EAUdrawWithFrame:` → … recurses until the stack overflows. (The `5517b91` warning cleanup renamed the methods into the override mechanism but left the `[super drawWithFrame:]` call, so the recursion is still live on `main`.)

Calling the `EAU*` helpers directly reproduces what `NSCell`'s `drawWithFrame:` would have done (border/background + interior) without re-entering the override.

## Verification

Launched a widget-gallery app containing a search field under three themes in a nested X server:

- Eau `4b4ae74` (unpatched): **crashes during startup**
- base GSTheme: starts fine
- Eau `4b4ae74` + this patch: **starts fine, search field present in the live tree**

Builds warning-free (`gmake`); no other behaviour change.

Closes #38
