### PR TITLE
Fix signed/unsigned comparison warnings (and a zero-count underflow) in tab/segmented drawing

### DIFF
--- a/Eau+TabView.m
+++ b/Eau+TabView.m
@@ -18,7 +18,7 @@
 {
   NSGraphicsContext *ctxt = GSCurrentContext();
   const NSUInteger howMany = [items count];
-  int i;
+  NSUInteger i;
   int previousState = 0;
   const NSTabViewType type = [(NSTabView *)view tabViewType];
   const NSRect bounds = [view bounds];

--- a/NSSegmentedCell+Eau.m
+++ b/NSSegmentedCell+Eau.m
@@ -44,7 +44,7 @@
   NSBezierPath* linesPath = [NSBezierPath bezierPath];
   [linesPath setLineWidth: 1];
   CGFloat offsetX = 0;
-  for (i = 0; i < count-1;i++)
+  for (i = 0; i < (NSInteger)count - 1; i++)
     {
       frame.size.width = [xself widthForSegment: i];
       if(frame.size.width == 0.0)


### PR DESCRIPTION
### What
- `Eau+TabView.m`: change the loop index from `int` to `NSUInteger` to match `count`.
- `NSSegmentedCell+Eau.m`: compare against `(NSInteger)count - 1` so the loop bound is evaluated as signed.

### Why
Removes the `-Wsign-compare` warnings. The signed bound also fixes an unsigned underflow: with zero segments, `count - 1` on an unsigned `count` wrapped to a huge value and the loop iterated over a near-unbounded range; it now correctly does nothing.

Fixes #40
