### PR TITLE
Use NSDebugLog for theme debug logging (drop the EAULOG macro)

### DIFF
--- a/Eau.h
+++ b/Eau.h
@@ -3,13 +3,6 @@
 #import <GNUstepGUI/GSTheme.h>
 #import "NSTableView+Eau.h"
 
-// To enable debugging messages in the _overrideClassMethod_foo mechanism
-#if 0
-#define EAULOG(args...) NSDebugLog(args)
-#else
-#define EAULOG(args...)
-#endif
-
 // Menu item horizontal padding in pixels. This value is the total horizontal
 // padding applied to a menu item and is split equally between the left and
 // right sides (e.g. 10.0 => 5 px on the left, 5 px on the right). The

--- a/Eau.m
+++ b/Eau.m
@@ -168,7 +168,7 @@ static EauUIBridgeProxy *gUIBridgeProxy = nil;
   gForceExternalMenuByEnv = EauEnvironmentContainsAppMenuToken();
   if (gForceExternalMenuByEnv)
     {
-      EAULOG(@"Eau: appmenu token detected in environment, forcing external menu mode");
+      NSDebugLog(@"Eau: appmenu token detected in environment, forcing external menu mode");
     }
   NSLog(@"Eau: +load called");
   // Schedule UIBridge service registration after a delay to ensure run loop is active
@@ -310,7 +310,7 @@ static Eau *gSharedEauInstance = nil;
   BOOL registered = [menuClientConnection registerName:clientName];
   if (!registered)
     {
-      EAULOG(@"Eau: Failed to register GNUstep menu client name: %@", clientName);
+      NSDebugLog(@"Eau: Failed to register GNUstep menu client name: %@", clientName);
       if (menuClientReceivePort != nil)
         {
           [[NSRunLoop currentRunLoop] removePort:menuClientReceivePort
@@ -327,8 +327,8 @@ static Eau *gSharedEauInstance = nil;
       return NO;
     }
 
-  EAULOG(@"Eau: Registered GNUstep menu client as %@ with receive port %@", clientName, [menuClientConnection receivePort]);
-  EAULOG(@"Eau: Registered GNUstep menu client as %@ with receive port added to run loop", clientName);
+  NSDebugLog(@"Eau: Registered GNUstep menu client as %@ with receive port %@", clientName, [menuClientConnection receivePort]);
+  NSDebugLog(@"Eau: Registered GNUstep menu client as %@ with receive port added to run loop", clientName);
   [[NSNotificationCenter defaultCenter] removeObserver:self name:NSConnectionDidDieNotification object:menuClientConnection];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(_menuClientConnectionDidDie:)
@@ -374,7 +374,7 @@ static Eau *gSharedEauInstance = nil;
                                                selector:@selector(_menuServerConnectionDidDie:)
                                                    name:NSConnectionDidDieNotification
                                                  object:menuServerConnection];
-      EAULOG(@"Eau: Connected to GNUstep menu server");
+      NSDebugLog(@"Eau: Connected to GNUstep menu server");
       return YES;
     }
 
@@ -528,11 +528,11 @@ static Eau *gSharedEauInstance = nil;
 
 - (id)initWithBundle:(NSBundle *)bundle
 {
-  EAULOG(@"Eau: >>> initWithBundle ENTRY (before super init)");
+  NSDebugLog(@"Eau: >>> initWithBundle ENTRY (before super init)");
   if ((self = [super initWithBundle:bundle]) != nil)
     {
-      EAULOG(@"Eau: >>> initWithBundle after super init, self=%p", self);
-      EAULOG(@"Eau: Initializing theme with bundle: %@", bundle);
+      NSDebugLog(@"Eau: >>> initWithBundle after super init, self=%p", self);
+      NSDebugLog(@"Eau: Initializing theme with bundle: %@", bundle);
       
       // Set shared instance for UIBridge service
       gSharedEauInstance = self;
@@ -577,36 +577,36 @@ static Eau *gSharedEauInstance = nil;
                name:NSMenuDidEndTrackingNotification
              object:nil];
 
-      EAULOG(@"Eau: GNUstep menu IPC initialized (Menu.app %@)",
+      NSDebugLog(@"Eau: GNUstep menu IPC initialized (Menu.app %@)",
              menuServerAvailable ? @"available" : @"unavailable");
 
       // Ensure alternating row background color is visible in Eau theme
       // Note: System color list may be read-only, so we wrap in try-catch
-      EAULOG(@"Eau: >>> About to check system color list");
+      NSDebugLog(@"Eau: >>> About to check system color list");
       @try
         {
           NSColorList *systemColors = [NSColorList colorListNamed: @"System"];
-          EAULOG(@"Eau: >>> System color list: %p, isEditable: %d",
+          NSDebugLog(@"Eau: >>> System color list: %p, isEditable: %d",
                  systemColors, systemColors ? [systemColors isEditable] : -1);
           if (systemColors != nil && [systemColors isEditable])
             {
-              EAULOG(@"Eau: >>> Setting alternateRowBackgroundColor");
+              NSDebugLog(@"Eau: >>> Setting alternateRowBackgroundColor");
               // Light gray with a touch of blue
               [systemColors setColor: [NSColor colorWithCalibratedRed: 0.94
                                                                  green: 0.95
                                                                   blue: 0.97
                                                                  alpha: 1.0]
                                forKey: @"alternateRowBackgroundColor"];
-              EAULOG(@"Eau: >>> alternateRowBackgroundColor set successfully");
+              NSDebugLog(@"Eau: >>> alternateRowBackgroundColor set successfully");
             }
           else
             {
-              EAULOG(@"Eau: >>> Skipping color list modification (nil or not editable)");
+              NSDebugLog(@"Eau: >>> Skipping color list modification (nil or not editable)");
             }
         }
       @catch (NSException *exception)
         {
-          EAULOG(@"Eau: Could not set alternating row color: %@", [exception reason]);
+          NSDebugLog(@"Eau: Could not set alternating row color: %@", [exception reason]);
         }
       // After ANY action is sent through a menu item (including keyboard
       // shortcuts matched to menu items), push updated enabled/state values
@@ -618,7 +618,7 @@ static Eau *gSharedEauInstance = nil;
                name:NSMenuDidSendActionNotification
              object:nil];
 
-      EAULOG(@"Eau: >>> initWithBundle EXIT");
+      NSDebugLog(@"Eau: >>> initWithBundle EXIT");
     }
   return self;
 }    
@@ -642,8 +642,8 @@ static Eau *gSharedEauInstance = nil;
 
 - (void)_menuClientConnectionDidDie:(NSNotification *)notification
 {
-  EAULOG(@"Eau: Menu client connection died");
-  EAULOG(@"Eau: Menu client connection died");
+  NSDebugLog(@"Eau: Menu client connection died");
+  NSDebugLog(@"Eau: Menu client connection died");
   if (menuClientReceivePort != nil)
     {
       [[NSRunLoop currentRunLoop] removePort:menuClientReceivePort
@@ -661,8 +661,8 @@ static Eau *gSharedEauInstance = nil;
 
 - (void)_menuServerConnectionDidDie:(NSNotification *)notification
 {
-  EAULOG(@"Eau: Menu server connection died");
-  EAULOG(@"Eau: Menu server connection died");
+  NSDebugLog(@"Eau: Menu server connection died");
+  NSDebugLog(@"Eau: Menu server connection died");
   menuServerConnection = nil;
   menuServerProxy = nil;
   menuServerConnected = NO;
@@ -679,12 +679,12 @@ static Eau *gSharedEauInstance = nil;
       NSWindow *keyWindow = [NSApp keyWindow];
       if (keyWindow != nil)
         {
-          EAULOG(@"Eau: Syncing GNUstep menu for key window: %@", keyWindow);
+          NSDebugLog(@"Eau: Syncing GNUstep menu for key window: %@", keyWindow);
           [self setMenu: menu forWindow: keyWindow];
         }
       else
         {
-          EAULOG(@"Eau: No key window available for menu change notification");
+          NSDebugLog(@"Eau: No key window available for menu change notification");
         }
     }
 }
@@ -699,12 +699,12 @@ static Eau *gSharedEauInstance = nil;
 
   if (mainMenu != nil && [mainMenu numberOfItems] > 0)
     {
-      EAULOG(@"Eau: Window became key, syncing GNUstep menu: %@", window);
+      NSDebugLog(@"Eau: Window became key, syncing GNUstep menu: %@", window);
       [self setMenu: mainMenu forWindow: window];
     }
   else
     {
-      EAULOG(@"Eau: Window became key but no main menu available: %@", window);
+      NSDebugLog(@"Eau: Window became key but no main menu available: %@", window);
     }
 }
 
@@ -733,23 +733,23 @@ static Eau *gSharedEauInstance = nil;
 - (void) sendMenu:(NSWindow*)w {
 
   NSNumber *windowId = [self _windowIdentifierForWindow:w];
-  EAULOG(@"Eau: sendMenu");
+  NSDebugLog(@"Eau: sendMenu");
   NSMenu *m = [menuByWindowId objectForKey:windowId];
 
   @try
     {
-      // EAULOG(@"Eau: Calling updateMenuForWindow on Menu.app server proxy");
+      // NSDebugLog(@"Eau: Calling updateMenuForWindow on Menu.app server proxy");
       NSDictionary *menuData = [self _serializeMenu:m];
 
       [(id<GSGNUstepMenuServer>)menuServerProxy updateMenuForWindow:windowId
 							   menuData:menuData
 							 clientName:[self _menuClientName]];
-      EAULOG(@"Eau: Successfully sent menu update to Menu.app");
-      EAULOG(@"Eau: Updated GNUstep menu for window %@", windowId);
+      NSDebugLog(@"Eau: Successfully sent menu update to Menu.app");
+      NSDebugLog(@"Eau: Updated GNUstep menu for window %@", windowId);
     }
   @catch (NSException *exception)
     {
-      EAULOG(@"Eau: Exception sending GNUstep menu: %@, falling back to standard menu", exception);
+      NSDebugLog(@"Eau: Exception sending GNUstep menu: %@, falling back to standard menu", exception);
       if (!gForceExternalMenuByEnv)
         {
           [super setMenu: m forWindow: w];
@@ -793,12 +793,12 @@ static Eau *gSharedEauInstance = nil;
             updateMenuEnabledStatesForWindow:windowId
                                     menuData:menuData
                                   clientName:[self _menuClientName]];
-          EAULOG(@"Eau: Pushed enabled states for window %@", windowId);
+          NSDebugLog(@"Eau: Pushed enabled states for window %@", windowId);
         }
     }
   @catch (NSException *exception)
     {
-      EAULOG(@"Eau: Exception pushing enabled states: %@", exception);
+      NSDebugLog(@"Eau: Exception pushing enabled states: %@", exception);
     }
 }
 
@@ -831,8 +831,8 @@ static Eau *gSharedEauInstance = nil;
   NSNumber *windowId = [self _windowIdentifierForWindow:w];
   if (windowId == nil)
     {
-      EAULOG(@"Eau: Could not resolve window identifier, using standard menu for window: %@", w);
-      EAULOG(@"Eau: Could not resolve window identifier, using standard menu for window: %@", w);
+      NSDebugLog(@"Eau: Could not resolve window identifier, using standard menu for window: %@", w);
+      NSDebugLog(@"Eau: Could not resolve window identifier, using standard menu for window: %@", w);
       if (!gForceExternalMenuByEnv)
         {
           [super setMenu: m forWindow: w];
@@ -842,7 +842,7 @@ static Eau *gSharedEauInstance = nil;
 
   if (m == nil || [m numberOfItems] == 0)
     {
-      EAULOG(@"Eau: Menu is nil or empty (items=%ld)", (long)[m numberOfItems]);
+      NSDebugLog(@"Eau: Menu is nil or empty (items=%ld)", (long)[m numberOfItems]);
       BOOL hadMenu = ([menuByWindowId objectForKey:windowId] != nil);
       [menuByWindowId removeObjectForKey:windowId];
 
@@ -850,18 +850,18 @@ static Eau *gSharedEauInstance = nil;
         {
           @try
             {
-              EAULOG(@"Eau: Unregistering window %@ from Menu.app", windowId);
+              NSDebugLog(@"Eau: Unregistering window %@ from Menu.app", windowId);
               [(id<GSGNUstepMenuServer>)menuServerProxy unregisterWindow:windowId
                                                                 clientName:[self _menuClientName]];
             }
           @catch (NSException *exception)
             {
-              EAULOG(@"Eau: Exception unregistering window %@: %@", windowId, exception);
-              EAULOG(@"Eau: Exception unregistering window %@: %@", windowId, exception);
+              NSDebugLog(@"Eau: Exception unregistering window %@: %@", windowId, exception);
+              NSDebugLog(@"Eau: Exception unregistering window %@: %@", windowId, exception);
             }
         }
 
-      EAULOG(@"Eau: Menu is nil or empty, using standard menu for window: %@", w);
+      NSDebugLog(@"Eau: Menu is nil or empty, using standard menu for window: %@", w);
       if (!gForceExternalMenuByEnv)
         {
           [super setMenu: m forWindow: w];
@@ -869,7 +869,7 @@ static Eau *gSharedEauInstance = nil;
       return;
     }
 
-  // EAULOG(@"Eau: Storing menu in cache for windowId=%@, menu has %ld items", windowId, (long)[m numberOfItems]);
+  // NSDebugLog(@"Eau: Storing menu in cache for windowId=%@, menu has %ld items", windowId, (long)[m numberOfItems]);
   // TOM: i believe this is redundant
   // [m update];
 
@@ -877,8 +877,8 @@ static Eau *gSharedEauInstance = nil;
 
   if (![self _ensureMenuClientRegistered])
     {
-      EAULOG(@"Eau: Failed to register GNUstep menu client, using standard menu for window: %@", w);
-      EAULOG(@"Eau: Failed to register GNUstep menu client, using standard menu for window: %@", w);
+      NSDebugLog(@"Eau: Failed to register GNUstep menu client, using standard menu for window: %@", w);
+      NSDebugLog(@"Eau: Failed to register GNUstep menu client, using standard menu for window: %@", w);
       if (!gForceExternalMenuByEnv)
         {
           [super setMenu: m forWindow: w];
@@ -888,8 +888,8 @@ static Eau *gSharedEauInstance = nil;
 
   if (![self _ensureMenuServerConnection])
     {
-      EAULOG(@"Eau: GNUstep menu server unavailable, automatic Menu.app restart disabled for window: %@", w);
-      EAULOG(@"Eau: GNUstep menu server unavailable, automatic Menu.app restart disabled for window: %@", w);
+      NSDebugLog(@"Eau: GNUstep menu server unavailable, automatic Menu.app restart disabled for window: %@", w);
+      NSDebugLog(@"Eau: GNUstep menu server unavailable, automatic Menu.app restart disabled for window: %@", w);
       // [[EauMenuRelaunchManager sharedManager] relaunchMenuProcessIfSnapshotAvailable];
       return;
     }
@@ -901,23 +901,23 @@ static Eau *gSharedEauInstance = nil;
 
 - (void)_performMenuActionFromIPC:(NSDictionary *)info
 {
-  EAULOG(@"Eau: _performMenuActionFromIPC called with info: %@", info);
-  EAULOG(@"Eau: _performMenuActionFromIPC called with info: %@", info);
+  NSDebugLog(@"Eau: _performMenuActionFromIPC called with info: %@", info);
+  NSDebugLog(@"Eau: _performMenuActionFromIPC called with info: %@", info);
   
   NSNumber *windowId = [info objectForKey:@"windowId"];
   NSArray *indexPath = [info objectForKey:@"indexPath"];
 
   if (windowId == nil || indexPath == nil)
     {
-      EAULOG(@"Eau: Invalid GNUstep menu action payload");
+      NSDebugLog(@"Eau: Invalid GNUstep menu action payload");
       return;
     }
 
   NSMenu *menu = [menuByWindowId objectForKey:windowId];
   if (menu == nil)
     {
-      EAULOG(@"Eau: No menu cached for window %@", windowId);
-      EAULOG(@"Eau: Available windows in cache: %@", [menuByWindowId allKeys]);
+      NSDebugLog(@"Eau: No menu cached for window %@", windowId);
+      NSDebugLog(@"Eau: Available windows in cache: %@", [menuByWindowId allKeys]);
       
       // Fallback: if we only have one cached menu, use it
       // This handles the case where the window ID doesn't match exactly
@@ -925,54 +925,54 @@ static Eau *gSharedEauInstance = nil;
       if ([menuByWindowId count] == 1)
         {
           menu = [[menuByWindowId allValues] firstObject];
-          EAULOG(@"Eau: Using fallback menu (only one cached menu)");
+          NSDebugLog(@"Eau: Using fallback menu (only one cached menu)");
         }
       else if ([menuByWindowId count] > 0)
         {
           // Multiple windows cached - use the first one (usually the main window)
           menu = [[menuByWindowId allValues] firstObject];
-          EAULOG(@"Eau: Using fallback menu (first of %lu cached menus)", (unsigned long)[menuByWindowId count]);
+          NSDebugLog(@"Eau: Using fallback menu (first of %lu cached menus)", (unsigned long)[menuByWindowId count]);
         }
       
       if (menu == nil)
         {
-          EAULOG(@"Eau: No cached menu available for fallback");
+          NSDebugLog(@"Eau: No cached menu available for fallback");
           return;
         }
     }
 
-  EAULOG(@"Eau: Found menu for window %@, looking up item at path %@", windowId, indexPath);
+  NSDebugLog(@"Eau: Found menu for window %@, looking up item at path %@", windowId, indexPath);
   
   NSMenuItem *menuItem = [self _menuItemForIndexPath:indexPath inMenu:menu];
   if (menuItem == nil)
     {
-      EAULOG(@"Eau: Menu item not found for window %@ path %@", windowId, indexPath);
+      NSDebugLog(@"Eau: Menu item not found for window %@ path %@", windowId, indexPath);
       return;
     }
 
-  EAULOG(@"Eau: Found menu item '%@', checking if enabled", [menuItem title]);
+  NSDebugLog(@"Eau: Found menu item '%@', checking if enabled", [menuItem title]);
   
   if (![menuItem isEnabled])
     {
-      EAULOG(@"Eau: Menu item '%@' disabled, ignoring", [menuItem title]);
+      NSDebugLog(@"Eau: Menu item '%@' disabled, ignoring", [menuItem title]);
       return;
     }
 
   SEL action = [menuItem action];
   id target = [menuItem target];
   
-  EAULOG(@"Eau: Menu item '%@' - action: %@, target: %@", [menuItem title], NSStringFromSelector(action), target);
+  NSDebugLog(@"Eau: Menu item '%@' - action: %@, target: %@", [menuItem title], NSStringFromSelector(action), target);
   
   if (action == NULL)
     {
-      EAULOG(@"Eau: Menu item '%@' has no action", [menuItem title]);
+      NSDebugLog(@"Eau: Menu item '%@' has no action", [menuItem title]);
       return;
     }
 
-  EAULOG(@"Eau: Sending action %@ to target %@ from menu item '%@'", NSStringFromSelector(action), target, [menuItem title]);
+  NSDebugLog(@"Eau: Sending action %@ to target %@ from menu item '%@'", NSStringFromSelector(action), target, [menuItem title]);
   BOOL handled __attribute__((unused)) = [NSApp sendAction:action to:target from:menuItem];
-  EAULOG(@"Eau: sendAction returned %@ for menu item '%@'", handled ? @"YES" : @"NO", [menuItem title]);
-  EAULOG(@"Eau: Action sent successfully");
+  NSDebugLog(@"Eau: sendAction returned %@ for menu item '%@'", handled ? @"YES" : @"NO", [menuItem title]);
+  NSDebugLog(@"Eau: Action sent successfully");
 }
 
 #pragma mark - UIBridgeProtocol (exposes only the frontmost/active window)
@@ -1394,8 +1394,8 @@ static Eau *gSharedEauInstance = nil;
 
 - (oneway void)activateMenuItemAtPath:(NSArray *)indexPath forWindow:(NSNumber *)windowId
 {
-  EAULOG(@"Eau: activateMenuItemAtPath called - indexPath: %@, windowId: %@", indexPath, windowId);
-  EAULOG(@"Eau: activateMenuItemAtPath called - indexPath: %@, windowId: %@", indexPath, windowId);
+  NSDebugLog(@"Eau: activateMenuItemAtPath called - indexPath: %@, windowId: %@", indexPath, windowId);
+  NSDebugLog(@"Eau: activateMenuItemAtPath called - indexPath: %@, windowId: %@", indexPath, windowId);
   
   NSDictionary *payload = [NSDictionary dictionaryWithObjectsAndKeys:
                            indexPath ?: [NSArray array], @"indexPath",
@@ -1404,14 +1404,14 @@ static Eau *gSharedEauInstance = nil;
 
   if (![NSThread isMainThread])
     {
-      EAULOG(@"Eau: Not on main thread, dispatching to main thread");
+      NSDebugLog(@"Eau: Not on main thread, dispatching to main thread");
       dispatch_async(dispatch_get_main_queue(), ^{
         [self _performMenuActionFromIPC:payload];
       });
       return;
     }
 
-  EAULOG(@"Eau: On main thread, calling _performMenuActionFromIPC directly");
+  NSDebugLog(@"Eau: On main thread, calling _performMenuActionFromIPC directly");
   [self _performMenuActionFromIPC:payload];
 }
 
@@ -1435,7 +1435,7 @@ static Eau *gSharedEauInstance = nil;
 
 - (bycopy id)validateMenuStateForWindow:(NSNumber *)windowId
 {
-  EAULOG(@"Eau: validateMenuStateForWindow called - windowId: %@", windowId);
+  NSDebugLog(@"Eau: validateMenuStateForWindow called - windowId: %@", windowId);
 
   if (![NSThread isMainThread])
     {
@@ -1475,7 +1475,7 @@ static Eau *gSharedEauInstance = nil;
 
   if (!menu)
     {
-      EAULOG(@"Eau: validateMenuStateForWindow: no menu found for window %@", windowId);
+      NSDebugLog(@"Eau: validateMenuStateForWindow: no menu found for window %@", windowId);
       return nil;
     }
 
@@ -1485,15 +1485,15 @@ static Eau *gSharedEauInstance = nil;
   // Return a flat array of @[title, enabled, state] triples.
   // No nested dictionaries — copies over DO in one batch instantly.
   NSArray *flat = [self _collectFlatStates:menu];
-  EAULOG(@"Eau: validateMenuStateForWindow: returning %lu flat items for window %@",
+  NSDebugLog(@"Eau: validateMenuStateForWindow: returning %lu flat items for window %@",
          (unsigned long)[flat count], windowId);
   return flat;
 }
 
 - (oneway void)requestMenuUpdateForWindow:(NSNumber *)windowId
 {
-  EAULOG(@"Eau: requestMenuUpdateForWindow called - windowId: %@", windowId);
-  EAULOG(@"Eau: requestMenuUpdateForWindow called - windowId: %@", windowId);
+  NSDebugLog(@"Eau: requestMenuUpdateForWindow called - windowId: %@", windowId);
+  NSDebugLog(@"Eau: requestMenuUpdateForWindow called - windowId: %@", windowId);
 
   if (![NSThread isMainThread])
     {
@@ -1523,12 +1523,12 @@ static Eau *gSharedEauInstance = nil;
 
   if (targetWindow)
     {
-      EAULOG(@"Eau: requestMenuUpdateForWindow: pushing menu for window %@", windowId);
+      NSDebugLog(@"Eau: requestMenuUpdateForWindow: pushing menu for window %@", windowId);
       [self setMenu:[NSApp mainMenu] forWindow:targetWindow];
     }
   else
     {
-      EAULOG(@"Eau: requestMenuUpdateForWindow: no window found for %@, cannot push", windowId);
+      NSDebugLog(@"Eau: requestMenuUpdateForWindow: no window found for %@, cannot push", windowId);
     }
 }
 
@@ -1542,11 +1542,11 @@ static Eau *gSharedEauInstance = nil;
   // Always use Menu.app IPC when available
   if ((menuServerAvailable || gForceExternalMenuByEnv) && ([NSApp mainMenu] == menu))
     {
-      EAULOG(@"Eau: Modifying menu rect for GNUstep IPC: hiding menu bar");
+      NSDebugLog(@"Eau: Modifying menu rect for GNUstep IPC: hiding menu bar");
       return NSZeroRect;
     }
   
-  EAULOG(@"Eau: Using standard menu rect (Menu.app %@)", menuServerAvailable ? @"available" : @"unavailable");
+  NSDebugLog(@"Eau: Using standard menu rect (Menu.app %@)", menuServerAvailable ? @"available" : @"unavailable");
   return [super modifyRect: rect forMenu: menu isHorizontal: horizontal];
 }
 
@@ -1555,11 +1555,11 @@ static Eau *gSharedEauInstance = nil;
   // Always use Menu.app IPC when available
   if ((menuServerAvailable || gForceExternalMenuByEnv) && ([NSApp mainMenu] == menu))
     {
-      EAULOG(@"Eau: Proposing menu visibility NO for GNUstep IPC");
+      NSDebugLog(@"Eau: Proposing menu visibility NO for GNUstep IPC");
       return NO;
     }
   
-  EAULOG(@"Eau: Proposing standard menu visibility %@ (Menu.app %@)", 
+  NSDebugLog(@"Eau: Proposing standard menu visibility %@ (Menu.app %@)", 
          visibility ? @"YES" : @"NO", menuServerAvailable ? @"available" : @"unavailable");
   return [super proposedVisibility: visibility forMenu: menu];
 }

--- a/Eau.m
+++ b/Eau.m
@@ -165,7 +165,7 @@ static EauUIBridgeProxy *gUIBridgeProxy = nil;
   gForceExternalMenuByEnv = EauEnvironmentContainsAppMenuToken();
   if (gForceExternalMenuByEnv)
     {
-      NSLog(@"Eau: appmenu token detected in environment, forcing external menu mode");
+      EAULOG(@"Eau: appmenu token detected in environment, forcing external menu mode");
     }
   NSLog(@"Eau: +load called");
   // Schedule UIBridge service registration after a delay to ensure run loop is active
@@ -639,7 +639,7 @@ static Eau *gSharedEauInstance = nil;
 
 - (void)_menuClientConnectionDidDie:(NSNotification *)notification
 {
-  NSLog(@"Eau: Menu client connection died");
+  EAULOG(@"Eau: Menu client connection died");
   EAULOG(@"Eau: Menu client connection died");
   if (menuClientReceivePort != nil)
     {
@@ -658,7 +658,7 @@ static Eau *gSharedEauInstance = nil;
 
 - (void)_menuServerConnectionDidDie:(NSNotification *)notification
 {
-  NSLog(@"Eau: Menu server connection died");
+  EAULOG(@"Eau: Menu server connection died");
   EAULOG(@"Eau: Menu server connection died");
   menuServerConnection = nil;
   menuServerProxy = nil;
@@ -730,18 +730,18 @@ static Eau *gSharedEauInstance = nil;
 - (void) sendMenu:(NSWindow*)w {
 
   NSNumber *windowId = [self _windowIdentifierForWindow:w];
-  NSLog(@"Eau: sendMenu");
+  EAULOG(@"Eau: sendMenu");
   NSMenu *m = [menuByWindowId objectForKey:windowId];
 
   @try
     {
-      // NSLog(@"Eau: Calling updateMenuForWindow on Menu.app server proxy");
+      // EAULOG(@"Eau: Calling updateMenuForWindow on Menu.app server proxy");
       NSDictionary *menuData = [self _serializeMenu:m];
 
       [(id<GSGNUstepMenuServer>)menuServerProxy updateMenuForWindow:windowId
 							   menuData:menuData
 							 clientName:[self _menuClientName]];
-      NSLog(@"Eau: Successfully sent menu update to Menu.app");
+      EAULOG(@"Eau: Successfully sent menu update to Menu.app");
       EAULOG(@"Eau: Updated GNUstep menu for window %@", windowId);
     }
   @catch (NSException *exception)
@@ -828,7 +828,7 @@ static Eau *gSharedEauInstance = nil;
   NSNumber *windowId = [self _windowIdentifierForWindow:w];
   if (windowId == nil)
     {
-      NSLog(@"Eau: Could not resolve window identifier, using standard menu for window: %@", w);
+      EAULOG(@"Eau: Could not resolve window identifier, using standard menu for window: %@", w);
       EAULOG(@"Eau: Could not resolve window identifier, using standard menu for window: %@", w);
       if (!gForceExternalMenuByEnv)
         {
@@ -839,7 +839,7 @@ static Eau *gSharedEauInstance = nil;
 
   if (m == nil || [m numberOfItems] == 0)
     {
-      NSLog(@"Eau: Menu is nil or empty (items=%ld)", (long)[m numberOfItems]);
+      EAULOG(@"Eau: Menu is nil or empty (items=%ld)", (long)[m numberOfItems]);
       BOOL hadMenu = ([menuByWindowId objectForKey:windowId] != nil);
       [menuByWindowId removeObjectForKey:windowId];
 
@@ -847,13 +847,13 @@ static Eau *gSharedEauInstance = nil;
         {
           @try
             {
-              NSLog(@"Eau: Unregistering window %@ from Menu.app", windowId);
+              EAULOG(@"Eau: Unregistering window %@ from Menu.app", windowId);
               [(id<GSGNUstepMenuServer>)menuServerProxy unregisterWindow:windowId
                                                                 clientName:[self _menuClientName]];
             }
           @catch (NSException *exception)
             {
-              NSLog(@"Eau: Exception unregistering window %@: %@", windowId, exception);
+              EAULOG(@"Eau: Exception unregistering window %@: %@", windowId, exception);
               EAULOG(@"Eau: Exception unregistering window %@: %@", windowId, exception);
             }
         }
@@ -866,7 +866,7 @@ static Eau *gSharedEauInstance = nil;
       return;
     }
 
-  // NSLog(@"Eau: Storing menu in cache for windowId=%@, menu has %ld items", windowId, (long)[m numberOfItems]);
+  // EAULOG(@"Eau: Storing menu in cache for windowId=%@, menu has %ld items", windowId, (long)[m numberOfItems]);
   // TOM: i believe this is redundant
   // [m update];
 
@@ -874,7 +874,7 @@ static Eau *gSharedEauInstance = nil;
 
   if (![self _ensureMenuClientRegistered])
     {
-      NSLog(@"Eau: Failed to register GNUstep menu client, using standard menu for window: %@", w);
+      EAULOG(@"Eau: Failed to register GNUstep menu client, using standard menu for window: %@", w);
       EAULOG(@"Eau: Failed to register GNUstep menu client, using standard menu for window: %@", w);
       if (!gForceExternalMenuByEnv)
         {
@@ -885,7 +885,7 @@ static Eau *gSharedEauInstance = nil;
 
   if (![self _ensureMenuServerConnection])
     {
-      NSLog(@"Eau: GNUstep menu server unavailable, automatic Menu.app restart disabled for window: %@", w);
+      EAULOG(@"Eau: GNUstep menu server unavailable, automatic Menu.app restart disabled for window: %@", w);
       EAULOG(@"Eau: GNUstep menu server unavailable, automatic Menu.app restart disabled for window: %@", w);
       // [[EauMenuRelaunchManager sharedManager] relaunchMenuProcessIfSnapshotAvailable];
       return;
@@ -898,7 +898,7 @@ static Eau *gSharedEauInstance = nil;
 
 - (void)_performMenuActionFromIPC:(NSDictionary *)info
 {
-  NSLog(@"Eau: _performMenuActionFromIPC called with info: %@", info);
+  EAULOG(@"Eau: _performMenuActionFromIPC called with info: %@", info);
   EAULOG(@"Eau: _performMenuActionFromIPC called with info: %@", info);
   
   NSNumber *windowId = [info objectForKey:@"windowId"];
@@ -967,8 +967,8 @@ static Eau *gSharedEauInstance = nil;
     }
 
   EAULOG(@"Eau: Sending action %@ to target %@ from menu item '%@'", NSStringFromSelector(action), target, [menuItem title]);
-  BOOL handled = [NSApp sendAction:action to:target from:menuItem];
-  NSLog(@"Eau: sendAction returned %@ for menu item '%@'", handled ? @"YES" : @"NO", [menuItem title]);
+  BOOL handled __attribute__((unused)) = [NSApp sendAction:action to:target from:menuItem];
+  EAULOG(@"Eau: sendAction returned %@ for menu item '%@'", handled ? @"YES" : @"NO", [menuItem title]);
   EAULOG(@"Eau: Action sent successfully");
 }
 
@@ -1391,7 +1391,7 @@ static Eau *gSharedEauInstance = nil;
 
 - (oneway void)activateMenuItemAtPath:(NSArray *)indexPath forWindow:(NSNumber *)windowId
 {
-  NSLog(@"Eau: activateMenuItemAtPath called - indexPath: %@, windowId: %@", indexPath, windowId);
+  EAULOG(@"Eau: activateMenuItemAtPath called - indexPath: %@, windowId: %@", indexPath, windowId);
   EAULOG(@"Eau: activateMenuItemAtPath called - indexPath: %@, windowId: %@", indexPath, windowId);
   
   NSDictionary *payload = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -1489,7 +1489,7 @@ static Eau *gSharedEauInstance = nil;
 
 - (oneway void)requestMenuUpdateForWindow:(NSNumber *)windowId
 {
-  NSLog(@"Eau: requestMenuUpdateForWindow called - windowId: %@", windowId);
+  EAULOG(@"Eau: requestMenuUpdateForWindow called - windowId: %@", windowId);
   EAULOG(@"Eau: requestMenuUpdateForWindow called - windowId: %@", windowId);
 
   if (![NSThread isMainThread])

--- a/GSInfoPanel+Eau.m
+++ b/GSInfoPanel+Eau.m
@@ -76,7 +76,7 @@
           method_exchangeImplementations(originalMethod, swizzledMethod);
         }
 
-      EAULOG(@"GSInfoPanel+Eau: Swizzled initWithDictionary:");
+      NSDebugLog(@"GSInfoPanel+Eau: Swizzled initWithDictionary:");
     }
   }
 

--- a/GSStandardDecorationView+Eau.m
+++ b/GSStandardDecorationView+Eau.m
@@ -26,7 +26,7 @@ static char originalFrameKey;  // Store original frame before zoom
 @implementation Eau(GSStandardWindowDecorationView)
 - (void) _overrideGSStandardWindowDecorationViewMethod_updateRects {
   GSStandardWindowDecorationView* xself = (GSStandardWindowDecorationView*)self;
-  EAULOG(@"GSStandardDecorationView+Eau updateRects");
+  NSDebugLog(@"GSStandardDecorationView+Eau updateRects");
   [xself EAUupdateRects];
 }
 @end
@@ -41,9 +41,9 @@ static char originalFrameKey;  // Store original frame before zoom
 
   // Initialize zoom button if not already done (only for resizable windows)
   NSUInteger styleMask = [[self window] styleMask];
-  EAULOG(@"Checking zoom button creation: hasZoomButton=%d, hasTitleBar=%d, resizable=%d", [self hasZoomButton], hasTitleBar, (int)(styleMask & NSResizableWindowMask));
+  NSDebugLog(@"Checking zoom button creation: hasZoomButton=%d, hasTitleBar=%d, resizable=%d", [self hasZoomButton], hasTitleBar, (int)(styleMask & NSResizableWindowMask));
   if (![self hasZoomButton] && hasTitleBar && (styleMask & NSResizableWindowMask)) {
-    EAULOG(@"Creating zoom button for window decoration view");
+    NSDebugLog(@"Creating zoom button for window decoration view");
     NSButton *zButton;
     if (isOrb) {
       EauWindowButton *orbButton = [[EauWindowButton alloc] init];
@@ -60,16 +60,16 @@ static char originalFrameKey;  // Store original frame before zoom
       zButton = [EauTitleBarButton maximizeButton];
     }
     if (zButton) {
-      EAULOG(@"Zoom button created successfully, setting up target and action");
+      NSDebugLog(@"Zoom button created successfully, setting up target and action");
       [self setZoomButton:zButton];
       [zButton setTarget:self];
       [zButton setAction:@selector(EAUzoomButtonClicked:)];
       [zButton setEnabled:YES];
       [self addSubview:zButton];
       [self setHasZoomButton:YES];
-      EAULOG(@"Zoom button target: %@, action: %@, window: %@", [zButton target], NSStringFromSelector([zButton action]), window);
+      NSDebugLog(@"Zoom button target: %@, action: %@, window: %@", [zButton target], NSStringFromSelector([zButton action]), window);
     } else {
-      EAULOG(@"Failed to create zoom button - zButton is nil");
+      NSDebugLog(@"Failed to create zoom button - zButton is nil");
     }
   }
 
@@ -182,7 +182,7 @@ static char originalFrameKey;  // Store original frame before zoom
 
       NSButton *zoomButton = [self zoomButton];
       if (zoomButton) {
-        EAULOG(@"Updating zoom button frame: %@", NSStringFromRect(zoomButtonRect));
+        NSDebugLog(@"Updating zoom button frame: %@", NSStringFromRect(zoomButtonRect));
 
         [zoomButton setTarget:self];
         [zoomButton setAction:@selector(EAUzoomButtonClicked:)];
@@ -236,39 +236,39 @@ static char originalFrameKey;  // Store original frame before zoom
 
 - (void) EAUzoomButtonClicked:(id)sender
 {
-  EAULOG(@"*** ZOOM BUTTON CLICKED! sender: %@, window: %@", sender, window);
-  EAULOG(@"*** Window isZoomed: %d", [window isZoomed]);
+  NSDebugLog(@"*** ZOOM BUTTON CLICKED! sender: %@, window: %@", sender, window);
+  NSDebugLog(@"*** Window isZoomed: %d", [window isZoomed]);
 
   if ([window isZoomed]) {
     // Window is zoomed, manually restore it to original frame
-    EAULOG(@"*** Window is zoomed, attempting manual unzoom");
+    NSDebugLog(@"*** Window is zoomed, attempting manual unzoom");
 
     NSValue *originalFrameValue = objc_getAssociatedObject(window, &originalFrameKey);
     if (originalFrameValue) {
       NSRect originalFrame = [originalFrameValue rectValue];
-      EAULOG(@"*** Restoring window to original frame: %@", NSStringFromRect(originalFrame));
+      NSDebugLog(@"*** Restoring window to original frame: %@", NSStringFromRect(originalFrame));
       [window setFrame:originalFrame display:YES animate:NO];
 
       // Clear the stored frame
       objc_setAssociatedObject(window, &originalFrameKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     } else {
-      EAULOG(@"*** No original frame stored, falling back to performZoom");
+      NSDebugLog(@"*** No original frame stored, falling back to performZoom");
       [window performZoom:sender];
     }
   } else {
     // Window is not zoomed, store current frame and zoom it
-    EAULOG(@"*** Window is not zoomed, storing frame and zooming");
+    NSDebugLog(@"*** Window is not zoomed, storing frame and zooming");
 
     // Store current frame before zooming
     NSRect currentFrame = [window frame];
     NSValue *frameValue = [NSValue valueWithRect:currentFrame];
     objc_setAssociatedObject(window, &originalFrameKey, frameValue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    EAULOG(@"*** Stored original frame: %@", NSStringFromRect(currentFrame));
+    NSDebugLog(@"*** Stored original frame: %@", NSStringFromRect(currentFrame));
 
     [window zoom:sender];
   }
 
-  EAULOG(@"*** After zoom call - Window isZoomed: %d", [window isZoomed]);
+  NSDebugLog(@"*** After zoom call - Window isZoomed: %d", [window isZoomed]);
 }
 
 #pragma mark - Title text truncation

--- a/GWDialog+Eau.m
+++ b/GWDialog+Eau.m
@@ -133,49 +133,49 @@ static void EAULayoutGWDialog(GWDialog *dialog)
      Cancel button should respond to Escape. This must be done carefully
      to avoid interfering with the existing target/action setup. */
   
-  EAULOG(@"EauDialog: Configuring button key equivalents and default button");
+  NSDebugLog(@"EauDialog: Configuring button key equivalents and default button");
   
   // Verify buttons exist and have proper targets/actions before modifying
   if (okButt && [okButt target] && [okButt action])
     {
-      EAULOG(@"EauDialog: OK button has target %@ and action %@", 
+      NSDebugLog(@"EauDialog: OK button has target %@ and action %@", 
              [okButt target], NSStringFromSelector([okButt action]));
       
       // Set Enter key to trigger OK button
       [okButt setKeyEquivalent: @"\r"];
       [okButt setKeyEquivalentModifierMask: 0];
-      EAULOG(@"EauDialog: Set OK button key equivalent to Enter");
+      NSDebugLog(@"EauDialog: Set OK button key equivalent to Enter");
       
       // Mark OK as the default button - this triggers pulsating animation
       NSButtonCell *okCell = [okButt cell];
       if (okCell)
         {
           [dialog setDefaultButtonCell: okCell];
-          EAULOG(@"EauDialog: Set OK button cell %@ as default button", okCell);
+          NSDebugLog(@"EauDialog: Set OK button cell %@ as default button", okCell);
         }
       else
         {
-          EAULOG(@"EauDialog: WARNING - OK button has no cell, cannot set as default");
+          NSDebugLog(@"EauDialog: WARNING - OK button has no cell, cannot set as default");
         }
     }
   else
     {
-      EAULOG(@"EauDialog: WARNING - OK button missing target or action, not setting key equivalent");
+      NSDebugLog(@"EauDialog: WARNING - OK button missing target or action, not setting key equivalent");
     }
   
   if (cancelButt && [cancelButt target] && [cancelButt action])
     {
-      EAULOG(@"EauDialog: Cancel button has target %@ and action %@",
+      NSDebugLog(@"EauDialog: Cancel button has target %@ and action %@",
              [cancelButt target], NSStringFromSelector([cancelButt action]));
       
       // Set Escape key to trigger Cancel button
       [cancelButt setKeyEquivalent: @"\e"];
       [cancelButt setKeyEquivalentModifierMask: 0];
-      EAULOG(@"EauDialog: Set Cancel button key equivalent to Escape");
+      NSDebugLog(@"EauDialog: Set Cancel button key equivalent to Escape");
     }
   else
     {
-      EAULOG(@"EauDialog: WARNING - Cancel button missing target or action, not setting key equivalent");
+      NSDebugLog(@"EauDialog: WARNING - Cancel button missing target or action, not setting key equivalent");
     }
 
   // Set up key view loop for tab navigation.
@@ -183,7 +183,7 @@ static void EAULayoutGWDialog(GWDialog *dialog)
   [editField setNextKeyView: okButt];
   [okButt setNextKeyView: cancelButt];
   [cancelButt setNextKeyView: editField];
-  EAULOG(@"EauDialog: Configured key view loop for tab navigation");
+  NSDebugLog(@"EauDialog: Configured key view loop for tab navigation");
 
   // Set initial first responder to the edit field for immediate keyboard input.
   // This ensures the text field gets focus automatically when the dialog opens,
@@ -191,13 +191,13 @@ static void EAULayoutGWDialog(GWDialog *dialog)
   // This is now safe because we don't set a problematic delegate on GWDialog
   // (see NSWindow+Eau.m eau_setDefaultButtonCell for delegate handling).
   [dialog setInitialFirstResponder: editField];
-  EAULOG(@"EauDialog: Set initial first responder to edit field %p", editField);
+  NSDebugLog(@"EauDialog: Set initial first responder to edit field %p", editField);
 
   // Position dialog using golden ratio centering.
   [dialog center];
 
   // Log dialog content for diagnostics.
-  EAULOG(@"EauDialog: GWDialog layout title='%@' edit='%@' switch='%@'", 
+  NSDebugLog(@"EauDialog: GWDialog layout title='%@' edit='%@' switch='%@'", 
          [titleField stringValue],
          [editField stringValue],
          (switchButt != nil) ? [switchButt title] : @"");
@@ -257,7 +257,7 @@ static void EAULayoutGWDialog(GWDialog *dialog)
   if (originalRunModal && eauRunModal)
     {
       method_exchangeImplementations(originalRunModal, eauRunModal);
-      EAULOG(@"GWDialog+Eau: Swizzled runModal for focus management");
+      NSDebugLog(@"GWDialog+Eau: Swizzled runModal for focus management");
     }
 
   // Swizzle NSWindow validRequestorForSendType:returnType: to avoid crashes
@@ -286,15 +286,15 @@ static void EAULayoutGWDialog(GWDialog *dialog)
                editText: (NSString *)eText
             switchTitle: (NSString *)swTitle
 {
-  EAULOG(@"EauDialog: Eau-themed init starting for title='%@'", title);
+  NSDebugLog(@"EauDialog: Eau-themed init starting for title='%@'", title);
   
   // Call the original implementation (which is now named eau_initWithTitle due to swizzling)
   id dialog = [self eau_initWithTitle: title editText: eText switchTitle: swTitle];
   if (dialog != nil)
     {
-      EAULOG(@"EauDialog: Original init completed, applying Eau layout and focus setup");
+      NSDebugLog(@"EauDialog: Original init completed, applying Eau layout and focus setup");
       EAULayoutGWDialog((GWDialog *)dialog);
-      EAULOG(@"EauDialog: Initialization complete for dialog %p", dialog);
+      NSDebugLog(@"EauDialog: Initialization complete for dialog %p", dialog);
     }
   return dialog;
 }
@@ -316,7 +316,7 @@ static void EAULayoutGWDialog(GWDialog *dialog)
  */
 - (NSModalResponse)eau_runModal
 {
-  EAULOG(@"GWDialog: eau_runModal called - activating app and making window key");
+  NSDebugLog(@"GWDialog: eau_runModal called - activating app and making window key");
   
   // Activate the application to bring it to front
   [[NSApplication sharedApplication] activateIgnoringOtherApps: YES];
@@ -324,7 +324,7 @@ static void EAULayoutGWDialog(GWDialog *dialog)
   // Make this dialog the key window so it receives keyboard input
   [self makeKeyAndOrderFront: nil];
   
-  EAULOG(@"GWDialog: Window is now key: %d, first responder: %@", 
+  NSDebugLog(@"GWDialog: Window is now key: %d, first responder: %@", 
          [self isKeyWindow], [[self firstResponder] class]);
   
   // Call the original runModal (which is now named eau_runModal due to swizzling)

--- a/NSAlert+Eau.m
+++ b/NSAlert+Eau.m
@@ -65,18 +65,18 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (id) initWithContentRect: (NSRect)rect
 {
-    EAULOG(@"Eau: EauAlertPanel initWithContentRect called");
+    NSDebugLog(@"Eau: EauAlertPanel initWithContentRect called");
     self = [super initWithContentRect: rect
                             styleMask: NSTitledWindowMask
                               backing: NSBackingStoreRetained
                                 defer: YES];
     if (self == nil)
     {
-        EAULOG(@"Eau: EauAlertPanel super init returned nil");
+        NSDebugLog(@"Eau: EauAlertPanel super init returned nil");
         return nil;
     }
     
-    EAULOG(@"Eau: EauAlertPanel setting properties");
+    NSDebugLog(@"Eau: EauAlertPanel setting properties");
     [self setTitle: @" "];
     [self setLevel: NSModalPanelWindowLevel];
     [self setHidesOnDeactivate: NO];
@@ -130,14 +130,14 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Buttons
     defButton = [self _makeButtonWithRect: NSZeroRect tag: NSAlertDefaultReturn];
     [defButton setKeyEquivalent: @"\r"];
-    // EAULOG(@"Eau: defButton key equivalent set to: '%@' - FORCED LOG", [defButton keyEquivalent]);
+    // NSDebugLog(@"Eau: defButton key equivalent set to: '%@' - FORCED LOG", [defButton keyEquivalent]);
     [defButton setHighlightsBy: NSPushInCellMask | NSChangeGrayCellMask | NSContentsCellMask];
     @try {
         [defButton setImagePosition: NSImageRight];
         [defButton setImage: [NSImage imageNamed: @"common_ret"]];
         [defButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
     } @catch (NSException *e) {
-        EAULOG(@"Eau: Exception loading button images: %@", e);
+        NSDebugLog(@"Eau: Exception loading button images: %@", e);
     }
     [defButton setFont: titleFont];  // Mark as default with bold font
     
@@ -151,13 +151,13 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     isGreen = YES;
     _isStoppingModal = NO;
     
-    EAULOG(@"Eau: EauAlertPanel initWithContentRect completed successfully");
+    NSDebugLog(@"Eau: EauAlertPanel initWithContentRect completed successfully");
     return self;
 }
 
 - (id) init
 {
-    EAULOG(@"Eau: EauAlertPanel init called");
+    NSDebugLog(@"Eau: EauAlertPanel init called");
 
     // Compute a centered initial frame so the X window is never created at
     // (0,0) (bottom-left in OS coordinates).  This prevents a visual flash
@@ -230,7 +230,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
             if ([box borderType] == NSGrooveBorder && [box frame].size.height <= 3.0)
             {
                 [box removeFromSuperview];
-                EAULOG(@"Eau: Removed horizontal line from GSAlertPanel");
+                NSDebugLog(@"Eau: Removed horizontal line from GSAlertPanel");
             }
         }
     }
@@ -254,7 +254,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 // This ensures focus and pulsing work for legacy alert panels
 - (NSInteger) eau_runModalHelper
 {
-    EAULOG(@"Eau: eau_runModalHelper called for GSAlertPanel");
+    NSDebugLog(@"Eau: eau_runModalHelper called for GSAlertPanel");
     
     // Get the default button from the ivar
     NSButton *defBtn = [self eau_getDefButton];
@@ -270,7 +270,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         [(NSPanel *)self makeFirstResponder: defBtn];
         // Set default button cell to enable pulsing animation
         [(NSPanel *)self setDefaultButtonCell: [defBtn cell]];
-        EAULOG(@"Eau: GSAlertPanel set default button focus and pulsing for button: %@", defBtn);
+        NSDebugLog(@"Eau: GSAlertPanel set default button focus and pulsing for button: %@", defBtn);
     }
     
     // Call the original runModal implementation
@@ -279,7 +279,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (void) dealloc
 {
-    EAULOG(@"Eau: EauAlertPanel dealloc called for panel: %p", self);
+    NSDebugLog(@"Eau: EauAlertPanel dealloc called for panel: %p", self);
     
     @try {
         // Stop any pending animations or callbacks
@@ -297,7 +297,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     messageField = nil;
     scroll = nil;
     
-    EAULOG(@"Eau: EauAlertPanel dealloc cleaning up completed");
+    NSDebugLog(@"Eau: EauAlertPanel dealloc cleaning up completed");
     // In ARC, [super dealloc] is NOT called - it happens automatically
 }
 
@@ -311,13 +311,13 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     [button setAction: @selector(buttonAction:)];
     [button setTag: tag];
     [button setFont: [NSFont systemFontOfSize: 0]];
-    EAULOG(@"Eau: Created button with tag %ld, target: %@, action: %@", tag, [button target], NSStringFromSelector([button action]));
+    NSDebugLog(@"Eau: Created button with tag %ld, target: %@, action: %@", tag, [button target], NSStringFromSelector([button action]));
     return button;
 }
 
 - (void) sizePanelToFit
 {
-    EAULOG(@"Eau: sizePanelToFit called");
+    NSDebugLog(@"Eau: sizePanelToFit called");
     @try {
     NSRect bounds;
     NSSize ssize;
@@ -540,45 +540,45 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     }
     
     isGreen = NO;
-    EAULOG(@"Eau: sizePanelToFit displaying content");
+    NSDebugLog(@"Eau: sizePanelToFit displaying content");
     [content display];
-    EAULOG(@"Eau: sizePanelToFit completed successfully");
+    NSDebugLog(@"Eau: sizePanelToFit completed successfully");
     }
     @catch (NSException *exception) {
-        EAULOG(@"Eau: EXCEPTION in sizePanelToFit: %@", exception);
-        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
-        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        NSDebugLog(@"Eau: EXCEPTION in sizePanelToFit: %@", exception);
+        NSDebugLog(@"Eau: Exception reason: %@", [exception reason]);
+        NSDebugLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 
 - (void) buttonAction: (id)sender
 {
-    EAULOG(@"Eau: buttonAction called, sender: %@, _isStoppingModal: %d", sender, _isStoppingModal);
+    NSDebugLog(@"Eau: buttonAction called, sender: %@, _isStoppingModal: %d", sender, _isStoppingModal);
     if (sender == nil)
     {
-        EAULOG(@"Eau: WARNING - buttonAction called with nil sender");
+        NSDebugLog(@"Eau: WARNING - buttonAction called with nil sender");
         return;
     }
     
     // Prevent re-entrant calls while stopping modal
     if (_isStoppingModal)
     {
-        EAULOG(@"Eau: WARNING - buttonAction called while already stopping modal, ignoring");
+        NSDebugLog(@"Eau: WARNING - buttonAction called while already stopping modal, ignoring");
         return;
     }
     
     NSInteger tag = [sender tag];
-    EAULOG(@"Eau: buttonAction tag: %ld", tag);
+    NSDebugLog(@"Eau: buttonAction tag: %ld", tag);
     if (![self isActivePanel])
     {
-        EAULOG(@"Eau: WARNING - buttonAction called when not in modal loop");
+        NSDebugLog(@"Eau: WARNING - buttonAction called when not in modal loop");
         return;
     }
     
     result = tag;
     _isStoppingModal = YES;
     
-    EAULOG(@"Eau: buttonAction will stop modal with result: %ld", result);
+    NSDebugLog(@"Eau: buttonAction will stop modal with result: %ld", result);
     
     // Defer stopping the modal to the next run loop iteration.
     // We use performSelector with specific modes because dispatch_async to the 
@@ -588,17 +588,17 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
                afterDelay: 0.0
                   inModes: [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSModalPanelRunLoopMode, nil]];
     
-    EAULOG(@"Eau: buttonAction scheduled deferred modal stop");
+    NSDebugLog(@"Eau: buttonAction scheduled deferred modal stop");
 }
 
 - (void) _stopModalDeferred
 {
     // Ensure we check isActivePanel to avoid stopping a context we don't own anymore
     if ([self isActivePanel] || [NSApp modalWindow] == self) {
-        EAULOG(@"Eau: _stopModalDeferred executing for result: %ld", result);
+        NSDebugLog(@"Eau: _stopModalDeferred executing for result: %ld", result);
         [NSApp stopModalWithCode: result];
     } else {
-        EAULOG(@"Eau: _stopModalDeferred skipped - panel no longer active");
+        NSDebugLog(@"Eau: _stopModalDeferred skipped - panel no longer active");
     }
     _isStoppingModal = NO;
 }
@@ -620,27 +620,27 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (NSInteger) runModal
 {
-    EAULOG(@"Eau: EauAlertPanel runModal called");
+    NSDebugLog(@"Eau: EauAlertPanel runModal called");
     
     // Beep when alert is displayed (diagnostics)
     NSApplication *app = [NSApplication sharedApplication];
-    EAULOG(@"Eau: EauAlertPanel about to beep - NSApp class: %@ respondsToSelector: %d",
+    NSDebugLog(@"Eau: EauAlertPanel about to beep - NSApp class: %@ respondsToSelector: %d",
           NSStringFromClass([app class]), (int)[app respondsToSelector:@selector(beep)]);
     if ([app respondsToSelector:@selector(beep)]) {
         [app performSelector:@selector(beep)];
     } else {
-        EAULOG(@"Eau: NSApp does not respond to -beep");
+        NSDebugLog(@"Eau: NSApp does not respond to -beep");
     }
     
     @try {
         if (isGreen)
         {
-            EAULOG(@"Eau: EauAlertPanel calling sizePanelToFit");
+            NSDebugLog(@"Eau: EauAlertPanel calling sizePanelToFit");
             [self sizePanelToFit];
-            EAULOG(@"Eau: EauAlertPanel sizePanelToFit completed");
+            NSDebugLog(@"Eau: EauAlertPanel sizePanelToFit completed");
         }
     
-        EAULOG(@"[EauTrace] EauAlertPanel runModal: BEFORE center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
+        NSDebugLog(@"[EauTrace] EauAlertPanel runModal: BEFORE center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
               NSStringFromRect([self frame]),
               [self frame].origin.x, [self frame].origin.y,
               [self frame].size.width, [self frame].size.height);
@@ -648,7 +648,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Ensure we're the key window and can handle events
     [self center];
     
-        EAULOG(@"[EauTrace] EauAlertPanel runModal: AFTER center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
+        NSDebugLog(@"[EauTrace] EauAlertPanel runModal: AFTER center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
               NSStringFromRect([self frame]),
               [self frame].origin.x, [self frame].origin.y,
               [self frame].size.width, [self frame].size.height);
@@ -656,7 +656,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Raise the window to ensure it gets input focus
     [NSApp activateIgnoringOtherApps: YES];
     [self orderFrontRegardless];
-        EAULOG(@"[EauTrace] EauAlertPanel runModal: AFTER orderFrontRegardless frame=%@",
+        NSDebugLog(@"[EauTrace] EauAlertPanel runModal: AFTER orderFrontRegardless frame=%@",
               NSStringFromRect([self frame]));
     [self makeKeyAndOrderFront: self];
     
@@ -666,20 +666,20 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         [self makeFirstResponder: defButton];
     }
     
-    EAULOG(@"Eau: runModal - window is key: %d", [self isKeyWindow]);
-    EAULOG(@"Eau: runModal - first responder: %@", [self firstResponder]);
+    NSDebugLog(@"Eau: runModal - window is key: %d", [self isKeyWindow]);
+    NSDebugLog(@"Eau: runModal - first responder: %@", [self firstResponder]);
     
-    EAULOG(@"Eau: About to call runModalForWindow");
+    NSDebugLog(@"Eau: About to call runModalForWindow");
     result = [NSApp runModalForWindow: self];
-    EAULOG(@"Eau: runModalForWindow returned with result: %ld", result);
+    NSDebugLog(@"Eau: runModalForWindow returned with result: %ld", result);
     [self orderOut: self];
-    EAULOG(@"Eau: EauAlertPanel runModal completed");
+    NSDebugLog(@"Eau: EauAlertPanel runModal completed");
     return result;
     }
     @catch (NSException *exception) {
-        EAULOG(@"Eau: EXCEPTION in EauAlertPanel runModal: %@", exception);
-        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
-        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        NSDebugLog(@"Eau: EXCEPTION in EauAlertPanel runModal: %@", exception);
+        NSDebugLog(@"Eau: Exception reason: %@", [exception reason]);
+        NSDebugLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
         return NSAlertErrorReturn;
     }
 }
@@ -687,7 +687,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 - (void) keyDown: (NSEvent *)event
 {
     NSString *chars = [event characters];
-    EAULOG(@"Eau: keyDown received: '%@'", chars);
+    NSDebugLog(@"Eau: keyDown received: '%@'", chars);
     if ([chars length] > 0)
     {
         unichar keyChar = [chars characterAtIndex: 0];
@@ -695,7 +695,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Handle Enter/Return for default button
     if (keyChar == '\r' && useControl(defButton))
     {
-        EAULOG(@"Eau: keyDown Enter pressed, clicking default button");
+        NSDebugLog(@"Eau: keyDown Enter pressed, clicking default button");
         [self buttonAction: defButton];
         return;
     }
@@ -703,7 +703,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Handle Spacebar for default button - CRITICAL
     if (keyChar == ' ' && useControl(defButton))
     {
-        EAULOG(@"Eau: keyDown Spacebar pressed, clicking default button");
+        NSDebugLog(@"Eau: keyDown Spacebar pressed, clicking default button");
         [self buttonAction: defButton];
         return;
     }
@@ -763,7 +763,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 {
     NSString *chars = [event characters];
     NSUInteger modifiers = [event modifierFlags] & NSDeviceIndependentModifierFlagsMask;
-    EAULOG(@"Eau: performKeyEquivalent received: '%@', modifiers: %lu, isActivePanel: %d", chars, (unsigned long)modifiers, [self isActivePanel]);
+    NSDebugLog(@"Eau: performKeyEquivalent received: '%@', modifiers: %lu, isActivePanel: %d", chars, (unsigned long)modifiers, [self isActivePanel]);
     
     // During modal operation, intercept ALL keyboard events to prevent app shortcuts
     if ([self isActivePanel])
@@ -771,7 +771,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // Handle Return/Enter for default button
         if ([chars isEqualToString: @"\r"] && useControl(defButton))
         {
-            EAULOG(@"Eau: performKeyEquivalent Enter pressed, clicking default button");
+            NSDebugLog(@"Eau: performKeyEquivalent Enter pressed, clicking default button");
             [self buttonAction: defButton];
             return YES;
         }
@@ -779,7 +779,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // Handle Spacebar for default button
         if ([chars isEqualToString: @" "] && modifiers == 0 && useControl(defButton))
         {
-            EAULOG(@"Eau: performKeyEquivalent Spacebar pressed, clicking default button");
+            NSDebugLog(@"Eau: performKeyEquivalent Spacebar pressed, clicking default button");
             [self buttonAction: defButton];
             return YES;
         }
@@ -787,7 +787,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // Handle Escape for cancel button
         if ([chars isEqualToString: @"\e"] && useControl(altButton) && [[altButton title] isEqualToString: @"Cancel"])
         {
-            EAULOG(@"Eau: performKeyEquivalent Escape pressed, clicking cancel button");
+            NSDebugLog(@"Eau: performKeyEquivalent Escape pressed, clicking cancel button");
             [self buttonAction: altButton];
             return YES;
         }
@@ -795,7 +795,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // CRITICAL: Block ALL other keyboard events while modal is active
         // This prevents ANY app-level shortcuts from interfering with the dialog
         // Return YES to consume the event and prevent it from reaching the application
-        EAULOG(@"Eau: Blocking event during modal: '%@' with modifiers: %lu", chars, (unsigned long)modifiers);
+        NSDebugLog(@"Eau: Blocking event during modal: '%@' with modifiers: %lu", chars, (unsigned long)modifiers);
         return YES;  // Consume ALL events to prevent app shortcuts
     }
     
@@ -807,7 +807,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     if ([event type] == NSKeyDown)
     {
         NSString *chars = [event characters];
-        EAULOG(@"Eau: sendEvent received keyDown: '%@', isActivePanel: %d", chars, [self isActivePanel]);
+        NSDebugLog(@"Eau: sendEvent received keyDown: '%@', isActivePanel: %d", chars, [self isActivePanel]);
         
         // CRITICAL: During modal operation, try performKeyEquivalent FIRST
         // This ensures keyboard events are handled by the dialog, not the app
@@ -815,7 +815,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         {
             if ([self performKeyEquivalent: event])
             {
-                EAULOG(@"Eau: Event consumed by performKeyEquivalent, not propagating to app");
+                NSDebugLog(@"Eau: Event consumed by performKeyEquivalent, not propagating to app");
                 return;  // Event was handled, DO NOT call super or keyDown
             }
         }
@@ -828,7 +828,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
             // Handle Return/Enter for default button
             if (keyChar == '\r' && useControl(defButton))
             {
-                EAULOG(@"Eau: sendEvent Enter pressed, clicking default button");
+                NSDebugLog(@"Eau: sendEvent Enter pressed, clicking default button");
                 [self buttonAction: defButton];
                 return;  // Don't call super - we handled it
             }
@@ -836,7 +836,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
             // Handle Spacebar for default button
             if (keyChar == ' ' && useControl(defButton))
             {
-                EAULOG(@"Eau: sendEvent Spacebar pressed, clicking default button");
+                NSDebugLog(@"Eau: sendEvent Spacebar pressed, clicking default button");
                 [self buttonAction: defButton];
                 return;  // Don't call super - we handled it
             }
@@ -844,7 +844,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
             // Handle Escape for cancel button
             if (keyChar == 0x1B && useControl(altButton) && [[altButton title] isEqualToString: @"Cancel"])
             {
-                EAULOG(@"Eau: sendEvent Escape pressed, clicking cancel button");
+                NSDebugLog(@"Eau: sendEvent Escape pressed, clicking cancel button");
                 [self buttonAction: altButton];
                 return;  // Don't call super - we handled it
             }
@@ -878,30 +878,30 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
                title: (NSString *)title
              message: (NSString *)message
 {
-    EAULOG(@"Eau: setTitleBar called with title='%@', message='%@'", title, message);
+    NSDebugLog(@"Eau: setTitleBar called with title='%@', message='%@'", title, message);
     @try {
     NSView *content = [self contentView];
     if (content == nil)
     {
-        EAULOG(@"Eau: WARNING - contentView is nil");
+        NSDebugLog(@"Eau: WARNING - contentView is nil");
         return;
     }
     
-    EAULOG(@"Eau: Setting window title");
+    NSDebugLog(@"Eau: Setting window title");
     if (titleBar != nil)
         [self setTitle: titleBar];
     
-    EAULOG(@"Eau: Setting icon");
+    NSDebugLog(@"Eau: Setting icon");
     if (icon != nil)
         [icoButton setImage: icon];
     
     if (title == nil)
         title = titleBar;
     
-    EAULOG(@"Eau: Setting title field");
+    NSDebugLog(@"Eau: Setting title field");
     setControl(content, titleField, title);
     
-    EAULOG(@"Eau: Handling scroll view");
+    NSDebugLog(@"Eau: Handling scroll view");
     if (useControl(scroll))
     {
         [scroll setDocumentView: nil];
@@ -909,18 +909,18 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         [messageField removeFromSuperview];
     }
     
-    EAULOG(@"Eau: Setting message field");
+    NSDebugLog(@"Eau: Setting message field");
     setControl(content, messageField, message);
     
     // Always use left alignment for consistent appearance
     [messageField setAlignment: NSLeftTextAlignment];
     
-    EAULOG(@"Eau: setTitleBar completed successfully");
+    NSDebugLog(@"Eau: setTitleBar completed successfully");
     }
     @catch (NSException *exception) {
-        EAULOG(@"Eau: EXCEPTION in setTitleBar: %@", exception);
-        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
-        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        NSDebugLog(@"Eau: EXCEPTION in setTitleBar: %@", exception);
+        NSDebugLog(@"Eau: Exception reason: %@", [exception reason]);
+        NSDebugLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 
@@ -1006,24 +1006,24 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (void) setButtons: (NSArray *)buttons
 {
-    EAULOG(@"Eau: setButtons called with %lu buttons", (unsigned long)[buttons count]);
+    NSDebugLog(@"Eau: setButtons called with %lu buttons", (unsigned long)[buttons count]);
     @try {
     NSView *content = [self contentView];
     if (content == nil)
     {
-        EAULOG(@"Eau: WARNING - contentView is nil in setButtons");
+        NSDebugLog(@"Eau: WARNING - contentView is nil in setButtons");
         return;
     }
     NSUInteger count = [buttons count];
     
-    EAULOG(@"Eau: Setting button 0");
+    NSDebugLog(@"Eau: Setting button 0");
     setButton(content, defButton, count > 0 ? [buttons objectAtIndex: 0] : nil);
-    EAULOG(@"Eau: Setting button 1");
+    NSDebugLog(@"Eau: Setting button 1");
     setButton(content, altButton, count > 1 ? [buttons objectAtIndex: 1] : nil);
-    EAULOG(@"Eau: Setting button 2");
+    NSDebugLog(@"Eau: Setting button 2");
     setButton(content, othButton, count > 2 ? [buttons objectAtIndex: 2] : nil);
     
-    EAULOG(@"Eau: Setting up first responder");
+    NSDebugLog(@"Eau: Setting up first responder");
     if (useControl(defButton))
     {
         [self makeFirstResponder: defButton];
@@ -1033,7 +1033,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     else
         [self makeFirstResponder: self];
     
-    EAULOG(@"Eau: Setting up key view chain");
+    NSDebugLog(@"Eau: Setting up key view chain");
     if (count > 2)
     {
         [defButton setNextKeyView: othButton];
@@ -1051,17 +1051,17 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         [defButton setNextKeyView: nil];
     }
     
-    EAULOG(@"Eau: Calling sizePanelToFit from setButtons");
+    NSDebugLog(@"Eau: Calling sizePanelToFit from setButtons");
     [self sizePanelToFit];
-    EAULOG(@"Eau: sizePanelToFit completed from setButtons");
+    NSDebugLog(@"Eau: sizePanelToFit completed from setButtons");
     isGreen = YES;
     result = NSAlertErrorReturn;
-    EAULOG(@"Eau: setButtons completed successfully");
+    NSDebugLog(@"Eau: setButtons completed successfully");
     }
     @catch (NSException *exception) {
-        EAULOG(@"Eau: EXCEPTION in setButtons: %@", exception);
-        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
-        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        NSDebugLog(@"Eau: EXCEPTION in setButtons: %@", exception);
+        NSDebugLog(@"Eau: Exception reason: %@", [exception reason]);
+        NSDebugLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 
@@ -1182,21 +1182,21 @@ static void setKeyEquivalent(NSButton *button)
         return;
     didSwizzle = YES;
     
-    EAULOG(@"Eau: Installing NSAlert customizations");
-    // EAULOG(@"Eau: Installing NSAlert customizations - FORCED LOG");
+    NSDebugLog(@"Eau: Installing NSAlert customizations");
+    // NSDebugLog(@"Eau: Installing NSAlert customizations - FORCED LOG");
     
     // Swizzle NSAlert's _setupPanel to use EauAlertPanel
     Class alertClass = NSClassFromString(@"NSAlert");
     SEL origSetupSel = @selector(_setupPanel);
     SEL swizzledSetupSel = @selector(eau_setupPanel);
     
-    // EAULOG(@"Eau: Found NSAlert class: %@", alertClass);
+    // NSDebugLog(@"Eau: Found NSAlert class: %@", alertClass);
     
     Method origSetupMethod = class_getInstanceMethod(alertClass, origSetupSel);
     Method swizzledSetupMethod = class_getInstanceMethod(alertClass, swizzledSetupSel);
     
-    // EAULOG(@"Eau: Original _setupPanel method: %p", origSetupMethod);
-    // EAULOG(@"Eau: Swizzled eau_setupPanel method: %p", swizzledSetupMethod);
+    // NSDebugLog(@"Eau: Original _setupPanel method: %p", origSetupMethod);
+    // NSDebugLog(@"Eau: Swizzled eau_setupPanel method: %p", swizzledSetupMethod);
     
     if (origSetupMethod && swizzledSetupMethod)
     {
@@ -1215,13 +1215,13 @@ static void setKeyEquivalent(NSButton *button)
         {
             method_exchangeImplementations(origSetupMethod, swizzledSetupMethod);
         }
-        EAULOG(@"Eau: NSAlert _setupPanel swizzled successfully");
-        // EAULOG(@"Eau: NSAlert _setupPanel swizzled successfully - FORCED LOG");
+        NSDebugLog(@"Eau: NSAlert _setupPanel swizzled successfully");
+        // NSDebugLog(@"Eau: NSAlert _setupPanel swizzled successfully - FORCED LOG");
     }
     else
     {
-        EAULOG(@"Eau: Warning - could not find _setupPanel method to swizzle");
-        // EAULOG(@"Eau: Warning - could not find _setupPanel method to swizzle - FORCED LOG");
+        NSDebugLog(@"Eau: Warning - could not find _setupPanel method to swizzle");
+        // NSDebugLog(@"Eau: Warning - could not find _setupPanel method to swizzle - FORCED LOG");
     }
     
     // Swizzle NSAlert's runModal to ensure proper activation
@@ -1248,11 +1248,11 @@ static void setKeyEquivalent(NSButton *button)
         {
             method_exchangeImplementations(origRunModalMethod, swizzledRunModalMethod);
         }
-        EAULOG(@"Eau: NSAlert runModal swizzled successfully");
+        NSDebugLog(@"Eau: NSAlert runModal swizzled successfully");
     }
     else
     {
-        EAULOG(@"Eau: Warning - could not find runModal method to swizzle");
+        NSDebugLog(@"Eau: Warning - could not find runModal method to swizzle");
     }
     
     // Also swizzle GSAlertPanel's _initWithoutGModel to handle legacy alert functions
@@ -1278,7 +1278,7 @@ static void setKeyEquivalent(NSButton *button)
             if (origInitMethod && newSwizzledMethod)
             {
                 method_exchangeImplementations(origInitMethod, newSwizzledMethod);
-                EAULOG(@"Eau: GSAlertPanel _initWithoutGModel swizzled successfully");
+                NSDebugLog(@"Eau: GSAlertPanel _initWithoutGModel swizzled successfully");
             }
         }
 
@@ -1293,7 +1293,7 @@ static void setKeyEquivalent(NSButton *button)
 // - Avoids KVC retain/release side effects on _window
 - (NSInteger) eau_runModal
 {
-    EAULOG(@"Eau: NSAlert eau_runModal called");
+    NSDebugLog(@"Eau: NSAlert eau_runModal called");
     @try {
 
     if (![NSThread isMainThread])
@@ -1311,12 +1311,12 @@ static void setKeyEquivalent(NSButton *button)
     
     // Beep when alert is displayed (diagnostics)
     NSApplication *eauApp = [NSApplication sharedApplication];
-    EAULOG(@"Eau: NSAlert about to beep - NSApp class: %@ respondsToSelector: %d",
+    NSDebugLog(@"Eau: NSAlert about to beep - NSApp class: %@ respondsToSelector: %d",
           NSStringFromClass([eauApp class]), (int)[eauApp respondsToSelector:@selector(beep)]);
     if ([eauApp respondsToSelector:@selector(beep)]) {
         [eauApp performSelector:@selector(beep)];
     } else {
-        EAULOG(@"Eau: NSApp does not respond to -beep");
+        NSDebugLog(@"Eau: NSApp does not respond to -beep");
     }
     
     // Get the _window ivar (NSAlert owns the panel instance)
@@ -1353,7 +1353,7 @@ static void setKeyEquivalent(NSButton *button)
                     if ([textField isEditable])
                     {
                         firstTextField = textField;
-                        EAULOG(@"NSAlert+Eau: Found editable text field %p in alert", textField);
+                        NSDebugLog(@"NSAlert+Eau: Found editable text field %p in alert", textField);
                         break;
                     }
                 }
@@ -1362,21 +1362,21 @@ static void setKeyEquivalent(NSButton *button)
             // Set initial first responder to enable immediate keyboard input
             if (firstTextField)
             {
-                EAULOG(@"NSAlert+Eau: Setting initial first responder to text field %p", firstTextField);
+                NSDebugLog(@"NSAlert+Eau: Setting initial first responder to text field %p", firstTextField);
                 [window setInitialFirstResponder: firstTextField];
             }
             else
             {
-                EAULOG(@"NSAlert+Eau: No editable text field found in alert");
+                NSDebugLog(@"NSAlert+Eau: No editable text field found in alert");
             }
         }
         
         // CRITICAL: Make the alert window key so it receives keyboard input immediately.
         // Without this, the alert appears but doesn't have focus - user must click it.
-        EAULOG(@"NSAlert+Eau: Activating app and making alert window key for immediate input");
+        NSDebugLog(@"NSAlert+Eau: Activating app and making alert window key for immediate input");
         [NSApp activateIgnoringOtherApps: YES];
         [window makeKeyAndOrderFront: nil];
-        EAULOG(@"NSAlert+Eau: Alert window is now key: %d", [window isKeyWindow]);
+        NSDebugLog(@"NSAlert+Eau: Alert window is now key: %d", [window isKeyWindow]);
 
         if ([window isKindOfClass: [EauAlertPanel class]])
         {
@@ -1390,7 +1390,7 @@ static void setKeyEquivalent(NSButton *button)
             [window orderFrontRegardless];
             [window makeKeyAndOrderFront: nil];
             
-            EAULOG(@"Eau: NSAlert running modal for window: %@", window);
+            NSDebugLog(@"Eau: NSAlert running modal for window: %@", window);
             [NSApp runModalForWindow: window];
             if ([window respondsToSelector: @selector(result)])
             {
@@ -1420,13 +1420,13 @@ static void setKeyEquivalent(NSButton *button)
     }
     
     // Fallback: if window creation failed, return failure
-    EAULOG(@"Eau: NSAlert eau_runModal - window was nil, returning NSAlertFirstButtonReturn");
+    NSDebugLog(@"Eau: NSAlert eau_runModal - window was nil, returning NSAlertFirstButtonReturn");
     return NSAlertFirstButtonReturn;
     }
     @catch (NSException *exception) {
-        EAULOG(@"Eau: FATAL EXCEPTION in eau_runModal: %@", exception);
-        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
-        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        NSDebugLog(@"Eau: FATAL EXCEPTION in eau_runModal: %@", exception);
+        NSDebugLog(@"Eau: Exception reason: %@", [exception reason]);
+        NSDebugLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
         return NSAlertErrorReturn;
     }
 }
@@ -1434,14 +1434,14 @@ static void setKeyEquivalent(NSButton *button)
 // Cleanup helper to clear NSAlert's window after modal teardown.
 - (void)eau_cleanupPanel
 {
-    EAULOG(@"Eau: eau_cleanupPanel called for NSAlert %p", self);
+    NSDebugLog(@"Eau: eau_cleanupPanel called for NSAlert %p", self);
     Ivar windowIvar = class_getInstanceVariable([self class], "_window");
     if (windowIvar)
     {
         // Check current value
         id currentWindow = object_getIvar(self, windowIvar);
         if (currentWindow) {
-            EAULOG(@"Eau: Cleaning up window %p before release", currentWindow);
+            NSDebugLog(@"Eau: Cleaning up window %p before release", currentWindow);
             @try {
                 // Ensure pulse animation and delegate are cleared while window is still alive
                 if ([currentWindow respondsToSelector: @selector(setDefaultButtonCell:)]) {
@@ -1451,17 +1451,17 @@ static void setKeyEquivalent(NSButton *button)
                     [currentWindow setDelegate: nil];
                 }
             } @catch (NSException *e) {
-                EAULOG(@"Eau: Exception during window cleanup: %@", e);
+                NSDebugLog(@"Eau: Exception during window cleanup: %@", e);
             }
             
-            EAULOG(@"Eau: Clearing _window ivar and associated object on NSAlert");
+            NSDebugLog(@"Eau: Clearing _window ivar and associated object on NSAlert");
             object_setIvar(self, windowIvar, nil);
             objc_setAssociatedObject(self, kEAUAlertWindowRetainKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
     }
     else
     {
-        EAULOG(@"Eau: _window ivar not found during cleanup, trying KVC");
+        NSDebugLog(@"Eau: _window ivar not found during cleanup, trying KVC");
         @try {
             [self setValue: nil forKey: @"_window"];
             objc_setAssociatedObject(self, kEAUAlertWindowRetainKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1476,23 +1476,23 @@ static void setKeyEquivalent(NSButton *button)
 // Builds a themed EauAlertPanel and assigns it to NSAlert's _window ivar.
 - (void) eau_setupPanel
 {
-    EAULOG(@"Eau: eau_setupPanel called for NSAlert");
+    NSDebugLog(@"Eau: eau_setupPanel called for NSAlert");
     
     EauAlertPanel *panel;
     NSString *title;
     
     @try {
-    EAULOG(@"Eau: Creating EauAlertPanel");
+    NSDebugLog(@"Eau: Creating EauAlertPanel");
     panel = [[EauAlertPanel alloc] init];
     if (panel == nil)
     {
-        EAULOG(@"Eau: CRITICAL - EauAlertPanel init returned nil");
+        NSDebugLog(@"Eau: CRITICAL - EauAlertPanel init returned nil");
         return;
     }
-    EAULOG(@"Eau: EauAlertPanel created successfully: %@", panel);
+    NSDebugLog(@"Eau: EauAlertPanel created successfully: %@", panel);
     
     // Access NSAlert's ivars through KVC or accessor methods
-    EAULOG(@"Eau: Accessing NSAlert properties");
+    NSDebugLog(@"Eau: Accessing NSAlert properties");
     NSAlertStyle style = NSWarningAlertStyle;
     NSString *messageText = nil;
     NSString *informativeText = nil;
@@ -1501,43 +1501,43 @@ static void setKeyEquivalent(NSButton *button)
     
     @try {
         style = [self alertStyle];
-        EAULOG(@"Eau: alertStyle: %ld", (long)style);
+        NSDebugLog(@"Eau: alertStyle: %ld", (long)style);
     } @catch (NSException *e) {
-        EAULOG(@"Eau: Exception getting alertStyle: %@", e);
+        NSDebugLog(@"Eau: Exception getting alertStyle: %@", e);
     }
     
     @try {
         messageText = [self messageText];
-        EAULOG(@"Eau: messageText: %@", messageText);
+        NSDebugLog(@"Eau: messageText: %@", messageText);
     } @catch (NSException *e) {
-        EAULOG(@"Eau: Exception getting messageText: %@", e);
+        NSDebugLog(@"Eau: Exception getting messageText: %@", e);
     }
     
     @try {
         informativeText = [self informativeText];
-        EAULOG(@"Eau: informativeText: %@", informativeText);
+        NSDebugLog(@"Eau: informativeText: %@", informativeText);
     } @catch (NSException *e) {
-        EAULOG(@"Eau: Exception getting informativeText: %@", e);
+        NSDebugLog(@"Eau: Exception getting informativeText: %@", e);
     }
     
     @try {
         icon = [self icon];
-        EAULOG(@"Eau: icon: %@", icon);
+        NSDebugLog(@"Eau: icon: %@", icon);
     } @catch (NSException *e) {
-        EAULOG(@"Eau: Exception getting icon: %@", e);
+        NSDebugLog(@"Eau: Exception getting icon: %@", e);
     }
     
     @try {
         buttons = [self buttons];
-        EAULOG(@"Eau: buttons count: %lu", (unsigned long)[buttons count]);
+        NSDebugLog(@"Eau: buttons count: %lu", (unsigned long)[buttons count]);
     } @catch (NSException *e) {
-        EAULOG(@"Eau: Exception getting buttons: %@", e);
+        NSDebugLog(@"Eau: Exception getting buttons: %@", e);
     }
     
     // Set default icons based on alert style if no custom icon is provided
     if (icon == nil)
     {
-        EAULOG(@"Eau: No icon provided, using default for style %ld", (long)style);
+        NSDebugLog(@"Eau: No icon provided, using default for style %ld", (long)style);
         @try {
             switch (style)
             {
@@ -1553,9 +1553,9 @@ static void setKeyEquivalent(NSButton *button)
                     break;
             }
             if (icon != nil)
-                EAULOG(@"Eau: Loaded default icon: %@", icon);
+                NSDebugLog(@"Eau: Loaded default icon: %@", icon);
         } @catch (NSException *e) {
-            EAULOG(@"Eau: Exception loading default icon: %@", e);
+            NSDebugLog(@"Eau: Exception loading default icon: %@", e);
         }
     }
     
@@ -1573,60 +1573,60 @@ static void setKeyEquivalent(NSButton *button)
             break;
     }
     
-    EAULOG(@"Eau: Setting up panel with title and buttons");
+    NSDebugLog(@"Eau: Setting up panel with title and buttons");
     @try {
         [panel setTitleBar: title
                       icon: icon
                      title: messageText != nil ? messageText : @"Alert"
                    message: informativeText != nil ? informativeText : @""];
-        EAULOG(@"Eau: setTitleBar completed");
+        NSDebugLog(@"Eau: setTitleBar completed");
     } @catch (NSException *e) {
-        EAULOG(@"Eau: EXCEPTION in setTitleBar: %@", e);
+        NSDebugLog(@"Eau: EXCEPTION in setTitleBar: %@", e);
     }
     
     @try {
         if ([buttons count] == 0)
         {
-            EAULOG(@"Eau: No buttons, adding default OK button");
+            NSDebugLog(@"Eau: No buttons, adding default OK button");
             [self addButtonWithTitle: @"OK"];
             buttons = [self buttons];
         }
         
-        EAULOG(@"Eau: Setting %lu buttons on panel", (unsigned long)[buttons count]);
+        NSDebugLog(@"Eau: Setting %lu buttons on panel", (unsigned long)[buttons count]);
         [panel setButtons: buttons];
-        EAULOG(@"Eau: setButtons completed");
+        NSDebugLog(@"Eau: setButtons completed");
     } @catch (NSException *e) {
-        EAULOG(@"Eau: EXCEPTION in setButtons: %@", e);
+        NSDebugLog(@"Eau: EXCEPTION in setButtons: %@", e);
     }
     
     // Set the _window ivar directly when possible to avoid KVC retain/release side effects
-    EAULOG(@"Eau: Setting _window ivar on NSAlert");
+    NSDebugLog(@"Eau: Setting _window ivar on NSAlert");
     {
         Ivar windowIvar = class_getInstanceVariable([self class], "_window");
         if (windowIvar)
         {
             object_setIvar(self, windowIvar, panel);
             objc_setAssociatedObject(self, kEAUAlertWindowRetainKey, panel, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            EAULOG(@"Eau: Successfully set _window via ivar");
+            NSDebugLog(@"Eau: Successfully set _window via ivar");
         }
         else
         {
             @try {
                 [self setValue: panel forKey: @"_window"];
-                EAULOG(@"Eau: Successfully set _window via KVC");
+                NSDebugLog(@"Eau: Successfully set _window via KVC");
             }
             @catch (NSException *exception) {
-                EAULOG(@"Eau: CRITICAL - could not set _window ivar on NSAlert: %@", exception);
+                NSDebugLog(@"Eau: CRITICAL - could not set _window ivar on NSAlert: %@", exception);
             }
         }
     }
     
-    EAULOG(@"Eau: eau_setupPanel completed successfully");
+    NSDebugLog(@"Eau: eau_setupPanel completed successfully");
     }
     @catch (NSException *exception) {
-        EAULOG(@"Eau: FATAL EXCEPTION in eau_setupPanel: %@", exception);
-        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
-        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        NSDebugLog(@"Eau: FATAL EXCEPTION in eau_setupPanel: %@", exception);
+        NSDebugLog(@"Eau: Exception reason: %@", [exception reason]);
+        NSDebugLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 

--- a/NSAlert+Eau.m
+++ b/NSAlert+Eau.m
@@ -65,18 +65,18 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (id) initWithContentRect: (NSRect)rect
 {
-    NSLog(@"Eau: EauAlertPanel initWithContentRect called");
+    EAULOG(@"Eau: EauAlertPanel initWithContentRect called");
     self = [super initWithContentRect: rect
                             styleMask: NSTitledWindowMask
                               backing: NSBackingStoreRetained
                                 defer: YES];
     if (self == nil)
     {
-        NSLog(@"Eau: EauAlertPanel super init returned nil");
+        EAULOG(@"Eau: EauAlertPanel super init returned nil");
         return nil;
     }
     
-    NSLog(@"Eau: EauAlertPanel setting properties");
+    EAULOG(@"Eau: EauAlertPanel setting properties");
     [self setTitle: @" "];
     [self setLevel: NSModalPanelWindowLevel];
     [self setHidesOnDeactivate: NO];
@@ -130,14 +130,14 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Buttons
     defButton = [self _makeButtonWithRect: NSZeroRect tag: NSAlertDefaultReturn];
     [defButton setKeyEquivalent: @"\r"];
-    // NSLog(@"Eau: defButton key equivalent set to: '%@' - FORCED LOG", [defButton keyEquivalent]);
+    // EAULOG(@"Eau: defButton key equivalent set to: '%@' - FORCED LOG", [defButton keyEquivalent]);
     [defButton setHighlightsBy: NSPushInCellMask | NSChangeGrayCellMask | NSContentsCellMask];
     @try {
         [defButton setImagePosition: NSImageRight];
         [defButton setImage: [NSImage imageNamed: @"common_ret"]];
         [defButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
     } @catch (NSException *e) {
-        NSLog(@"Eau: Exception loading button images: %@", e);
+        EAULOG(@"Eau: Exception loading button images: %@", e);
     }
     [defButton setFont: titleFont];  // Mark as default with bold font
     
@@ -151,13 +151,13 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     isGreen = YES;
     _isStoppingModal = NO;
     
-    NSLog(@"Eau: EauAlertPanel initWithContentRect completed successfully");
+    EAULOG(@"Eau: EauAlertPanel initWithContentRect completed successfully");
     return self;
 }
 
 - (id) init
 {
-    NSLog(@"Eau: EauAlertPanel init called");
+    EAULOG(@"Eau: EauAlertPanel init called");
 
     // Compute a centered initial frame so the X window is never created at
     // (0,0) (bottom-left in OS coordinates).  This prevents a visual flash
@@ -279,7 +279,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (void) dealloc
 {
-    NSLog(@"Eau: EauAlertPanel dealloc called for panel: %p", self);
+    EAULOG(@"Eau: EauAlertPanel dealloc called for panel: %p", self);
     
     @try {
         // Stop any pending animations or callbacks
@@ -297,7 +297,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     messageField = nil;
     scroll = nil;
     
-    NSLog(@"Eau: EauAlertPanel dealloc cleaning up completed");
+    EAULOG(@"Eau: EauAlertPanel dealloc cleaning up completed");
     // In ARC, [super dealloc] is NOT called - it happens automatically
 }
 
@@ -317,7 +317,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (void) sizePanelToFit
 {
-    NSLog(@"Eau: sizePanelToFit called");
+    EAULOG(@"Eau: sizePanelToFit called");
     @try {
     NSRect bounds;
     NSSize ssize;
@@ -540,45 +540,45 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     }
     
     isGreen = NO;
-    NSLog(@"Eau: sizePanelToFit displaying content");
+    EAULOG(@"Eau: sizePanelToFit displaying content");
     [content display];
-    NSLog(@"Eau: sizePanelToFit completed successfully");
+    EAULOG(@"Eau: sizePanelToFit completed successfully");
     }
     @catch (NSException *exception) {
-        NSLog(@"Eau: EXCEPTION in sizePanelToFit: %@", exception);
-        NSLog(@"Eau: Exception reason: %@", [exception reason]);
-        NSLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        EAULOG(@"Eau: EXCEPTION in sizePanelToFit: %@", exception);
+        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
+        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 
 - (void) buttonAction: (id)sender
 {
-    NSLog(@"Eau: buttonAction called, sender: %@, _isStoppingModal: %d", sender, _isStoppingModal);
+    EAULOG(@"Eau: buttonAction called, sender: %@, _isStoppingModal: %d", sender, _isStoppingModal);
     if (sender == nil)
     {
-        NSLog(@"Eau: WARNING - buttonAction called with nil sender");
+        EAULOG(@"Eau: WARNING - buttonAction called with nil sender");
         return;
     }
     
     // Prevent re-entrant calls while stopping modal
     if (_isStoppingModal)
     {
-        NSLog(@"Eau: WARNING - buttonAction called while already stopping modal, ignoring");
+        EAULOG(@"Eau: WARNING - buttonAction called while already stopping modal, ignoring");
         return;
     }
     
     NSInteger tag = [sender tag];
-    NSLog(@"Eau: buttonAction tag: %ld", tag);
+    EAULOG(@"Eau: buttonAction tag: %ld", tag);
     if (![self isActivePanel])
     {
-        NSLog(@"Eau: WARNING - buttonAction called when not in modal loop");
+        EAULOG(@"Eau: WARNING - buttonAction called when not in modal loop");
         return;
     }
     
     result = tag;
     _isStoppingModal = YES;
     
-    NSLog(@"Eau: buttonAction will stop modal with result: %ld", result);
+    EAULOG(@"Eau: buttonAction will stop modal with result: %ld", result);
     
     // Defer stopping the modal to the next run loop iteration.
     // We use performSelector with specific modes because dispatch_async to the 
@@ -588,17 +588,17 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
                afterDelay: 0.0
                   inModes: [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSModalPanelRunLoopMode, nil]];
     
-    NSLog(@"Eau: buttonAction scheduled deferred modal stop");
+    EAULOG(@"Eau: buttonAction scheduled deferred modal stop");
 }
 
 - (void) _stopModalDeferred
 {
     // Ensure we check isActivePanel to avoid stopping a context we don't own anymore
     if ([self isActivePanel] || [NSApp modalWindow] == self) {
-        NSLog(@"Eau: _stopModalDeferred executing for result: %ld", result);
+        EAULOG(@"Eau: _stopModalDeferred executing for result: %ld", result);
         [NSApp stopModalWithCode: result];
     } else {
-        NSLog(@"Eau: _stopModalDeferred skipped - panel no longer active");
+        EAULOG(@"Eau: _stopModalDeferred skipped - panel no longer active");
     }
     _isStoppingModal = NO;
 }
@@ -620,27 +620,27 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (NSInteger) runModal
 {
-    NSLog(@"Eau: EauAlertPanel runModal called");
+    EAULOG(@"Eau: EauAlertPanel runModal called");
     
     // Beep when alert is displayed (diagnostics)
     NSApplication *app = [NSApplication sharedApplication];
-    NSLog(@"Eau: EauAlertPanel about to beep - NSApp class: %@ respondsToSelector: %d",
+    EAULOG(@"Eau: EauAlertPanel about to beep - NSApp class: %@ respondsToSelector: %d",
           NSStringFromClass([app class]), (int)[app respondsToSelector:@selector(beep)]);
     if ([app respondsToSelector:@selector(beep)]) {
         [app performSelector:@selector(beep)];
     } else {
-        NSLog(@"Eau: NSApp does not respond to -beep");
+        EAULOG(@"Eau: NSApp does not respond to -beep");
     }
     
     @try {
         if (isGreen)
         {
-            NSLog(@"Eau: EauAlertPanel calling sizePanelToFit");
+            EAULOG(@"Eau: EauAlertPanel calling sizePanelToFit");
             [self sizePanelToFit];
-            NSLog(@"Eau: EauAlertPanel sizePanelToFit completed");
+            EAULOG(@"Eau: EauAlertPanel sizePanelToFit completed");
         }
     
-        NSLog(@"[EauTrace] EauAlertPanel runModal: BEFORE center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
+        EAULOG(@"[EauTrace] EauAlertPanel runModal: BEFORE center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
               NSStringFromRect([self frame]),
               [self frame].origin.x, [self frame].origin.y,
               [self frame].size.width, [self frame].size.height);
@@ -648,7 +648,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Ensure we're the key window and can handle events
     [self center];
     
-        NSLog(@"[EauTrace] EauAlertPanel runModal: AFTER center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
+        EAULOG(@"[EauTrace] EauAlertPanel runModal: AFTER center frame=%@ OSorigin=(%.0f,%.0f) size=(%.0f,%.0f)",
               NSStringFromRect([self frame]),
               [self frame].origin.x, [self frame].origin.y,
               [self frame].size.width, [self frame].size.height);
@@ -656,7 +656,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Raise the window to ensure it gets input focus
     [NSApp activateIgnoringOtherApps: YES];
     [self orderFrontRegardless];
-        NSLog(@"[EauTrace] EauAlertPanel runModal: AFTER orderFrontRegardless frame=%@",
+        EAULOG(@"[EauTrace] EauAlertPanel runModal: AFTER orderFrontRegardless frame=%@",
               NSStringFromRect([self frame]));
     [self makeKeyAndOrderFront: self];
     
@@ -669,17 +669,17 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     EAULOG(@"Eau: runModal - window is key: %d", [self isKeyWindow]);
     EAULOG(@"Eau: runModal - first responder: %@", [self firstResponder]);
     
-    NSLog(@"Eau: About to call runModalForWindow");
+    EAULOG(@"Eau: About to call runModalForWindow");
     result = [NSApp runModalForWindow: self];
-    NSLog(@"Eau: runModalForWindow returned with result: %ld", result);
+    EAULOG(@"Eau: runModalForWindow returned with result: %ld", result);
     [self orderOut: self];
-    NSLog(@"Eau: EauAlertPanel runModal completed");
+    EAULOG(@"Eau: EauAlertPanel runModal completed");
     return result;
     }
     @catch (NSException *exception) {
-        NSLog(@"Eau: EXCEPTION in EauAlertPanel runModal: %@", exception);
-        NSLog(@"Eau: Exception reason: %@", [exception reason]);
-        NSLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        EAULOG(@"Eau: EXCEPTION in EauAlertPanel runModal: %@", exception);
+        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
+        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
         return NSAlertErrorReturn;
     }
 }
@@ -703,7 +703,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     // Handle Spacebar for default button - CRITICAL
     if (keyChar == ' ' && useControl(defButton))
     {
-        NSLog(@"Eau: keyDown Spacebar pressed, clicking default button");
+        EAULOG(@"Eau: keyDown Spacebar pressed, clicking default button");
         [self buttonAction: defButton];
         return;
     }
@@ -763,7 +763,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 {
     NSString *chars = [event characters];
     NSUInteger modifiers = [event modifierFlags] & NSDeviceIndependentModifierFlagsMask;
-    NSLog(@"Eau: performKeyEquivalent received: '%@', modifiers: %lu, isActivePanel: %d", chars, (unsigned long)modifiers, [self isActivePanel]);
+    EAULOG(@"Eau: performKeyEquivalent received: '%@', modifiers: %lu, isActivePanel: %d", chars, (unsigned long)modifiers, [self isActivePanel]);
     
     // During modal operation, intercept ALL keyboard events to prevent app shortcuts
     if ([self isActivePanel])
@@ -771,7 +771,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // Handle Return/Enter for default button
         if ([chars isEqualToString: @"\r"] && useControl(defButton))
         {
-            NSLog(@"Eau: performKeyEquivalent Enter pressed, clicking default button");
+            EAULOG(@"Eau: performKeyEquivalent Enter pressed, clicking default button");
             [self buttonAction: defButton];
             return YES;
         }
@@ -779,7 +779,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // Handle Spacebar for default button
         if ([chars isEqualToString: @" "] && modifiers == 0 && useControl(defButton))
         {
-            NSLog(@"Eau: performKeyEquivalent Spacebar pressed, clicking default button");
+            EAULOG(@"Eau: performKeyEquivalent Spacebar pressed, clicking default button");
             [self buttonAction: defButton];
             return YES;
         }
@@ -787,7 +787,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // Handle Escape for cancel button
         if ([chars isEqualToString: @"\e"] && useControl(altButton) && [[altButton title] isEqualToString: @"Cancel"])
         {
-            NSLog(@"Eau: performKeyEquivalent Escape pressed, clicking cancel button");
+            EAULOG(@"Eau: performKeyEquivalent Escape pressed, clicking cancel button");
             [self buttonAction: altButton];
             return YES;
         }
@@ -795,7 +795,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         // CRITICAL: Block ALL other keyboard events while modal is active
         // This prevents ANY app-level shortcuts from interfering with the dialog
         // Return YES to consume the event and prevent it from reaching the application
-        NSLog(@"Eau: Blocking event during modal: '%@' with modifiers: %lu", chars, (unsigned long)modifiers);
+        EAULOG(@"Eau: Blocking event during modal: '%@' with modifiers: %lu", chars, (unsigned long)modifiers);
         return YES;  // Consume ALL events to prevent app shortcuts
     }
     
@@ -807,7 +807,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     if ([event type] == NSKeyDown)
     {
         NSString *chars = [event characters];
-        NSLog(@"Eau: sendEvent received keyDown: '%@', isActivePanel: %d", chars, [self isActivePanel]);
+        EAULOG(@"Eau: sendEvent received keyDown: '%@', isActivePanel: %d", chars, [self isActivePanel]);
         
         // CRITICAL: During modal operation, try performKeyEquivalent FIRST
         // This ensures keyboard events are handled by the dialog, not the app
@@ -815,7 +815,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         {
             if ([self performKeyEquivalent: event])
             {
-                NSLog(@"Eau: Event consumed by performKeyEquivalent, not propagating to app");
+                EAULOG(@"Eau: Event consumed by performKeyEquivalent, not propagating to app");
                 return;  // Event was handled, DO NOT call super or keyDown
             }
         }
@@ -828,7 +828,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
             // Handle Return/Enter for default button
             if (keyChar == '\r' && useControl(defButton))
             {
-                NSLog(@"Eau: sendEvent Enter pressed, clicking default button");
+                EAULOG(@"Eau: sendEvent Enter pressed, clicking default button");
                 [self buttonAction: defButton];
                 return;  // Don't call super - we handled it
             }
@@ -836,7 +836,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
             // Handle Spacebar for default button
             if (keyChar == ' ' && useControl(defButton))
             {
-                NSLog(@"Eau: sendEvent Spacebar pressed, clicking default button");
+                EAULOG(@"Eau: sendEvent Spacebar pressed, clicking default button");
                 [self buttonAction: defButton];
                 return;  // Don't call super - we handled it
             }
@@ -844,7 +844,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
             // Handle Escape for cancel button
             if (keyChar == 0x1B && useControl(altButton) && [[altButton title] isEqualToString: @"Cancel"])
             {
-                NSLog(@"Eau: sendEvent Escape pressed, clicking cancel button");
+                EAULOG(@"Eau: sendEvent Escape pressed, clicking cancel button");
                 [self buttonAction: altButton];
                 return;  // Don't call super - we handled it
             }
@@ -878,30 +878,30 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
                title: (NSString *)title
              message: (NSString *)message
 {
-    NSLog(@"Eau: setTitleBar called with title='%@', message='%@'", title, message);
+    EAULOG(@"Eau: setTitleBar called with title='%@', message='%@'", title, message);
     @try {
     NSView *content = [self contentView];
     if (content == nil)
     {
-        NSLog(@"Eau: WARNING - contentView is nil");
+        EAULOG(@"Eau: WARNING - contentView is nil");
         return;
     }
     
-    NSLog(@"Eau: Setting window title");
+    EAULOG(@"Eau: Setting window title");
     if (titleBar != nil)
         [self setTitle: titleBar];
     
-    NSLog(@"Eau: Setting icon");
+    EAULOG(@"Eau: Setting icon");
     if (icon != nil)
         [icoButton setImage: icon];
     
     if (title == nil)
         title = titleBar;
     
-    NSLog(@"Eau: Setting title field");
+    EAULOG(@"Eau: Setting title field");
     setControl(content, titleField, title);
     
-    NSLog(@"Eau: Handling scroll view");
+    EAULOG(@"Eau: Handling scroll view");
     if (useControl(scroll))
     {
         [scroll setDocumentView: nil];
@@ -909,18 +909,18 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         [messageField removeFromSuperview];
     }
     
-    NSLog(@"Eau: Setting message field");
+    EAULOG(@"Eau: Setting message field");
     setControl(content, messageField, message);
     
     // Always use left alignment for consistent appearance
     [messageField setAlignment: NSLeftTextAlignment];
     
-    NSLog(@"Eau: setTitleBar completed successfully");
+    EAULOG(@"Eau: setTitleBar completed successfully");
     }
     @catch (NSException *exception) {
-        NSLog(@"Eau: EXCEPTION in setTitleBar: %@", exception);
-        NSLog(@"Eau: Exception reason: %@", [exception reason]);
-        NSLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        EAULOG(@"Eau: EXCEPTION in setTitleBar: %@", exception);
+        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
+        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 
@@ -1006,24 +1006,24 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
 
 - (void) setButtons: (NSArray *)buttons
 {
-    NSLog(@"Eau: setButtons called with %lu buttons", (unsigned long)[buttons count]);
+    EAULOG(@"Eau: setButtons called with %lu buttons", (unsigned long)[buttons count]);
     @try {
     NSView *content = [self contentView];
     if (content == nil)
     {
-        NSLog(@"Eau: WARNING - contentView is nil in setButtons");
+        EAULOG(@"Eau: WARNING - contentView is nil in setButtons");
         return;
     }
     NSUInteger count = [buttons count];
     
-    NSLog(@"Eau: Setting button 0");
+    EAULOG(@"Eau: Setting button 0");
     setButton(content, defButton, count > 0 ? [buttons objectAtIndex: 0] : nil);
-    NSLog(@"Eau: Setting button 1");
+    EAULOG(@"Eau: Setting button 1");
     setButton(content, altButton, count > 1 ? [buttons objectAtIndex: 1] : nil);
-    NSLog(@"Eau: Setting button 2");
+    EAULOG(@"Eau: Setting button 2");
     setButton(content, othButton, count > 2 ? [buttons objectAtIndex: 2] : nil);
     
-    NSLog(@"Eau: Setting up first responder");
+    EAULOG(@"Eau: Setting up first responder");
     if (useControl(defButton))
     {
         [self makeFirstResponder: defButton];
@@ -1033,7 +1033,7 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
     else
         [self makeFirstResponder: self];
     
-    NSLog(@"Eau: Setting up key view chain");
+    EAULOG(@"Eau: Setting up key view chain");
     if (count > 2)
     {
         [defButton setNextKeyView: othButton];
@@ -1051,17 +1051,17 @@ static const void *kEAUAlertWindowRetainKey = &kEAUAlertWindowRetainKey;
         [defButton setNextKeyView: nil];
     }
     
-    NSLog(@"Eau: Calling sizePanelToFit from setButtons");
+    EAULOG(@"Eau: Calling sizePanelToFit from setButtons");
     [self sizePanelToFit];
-    NSLog(@"Eau: sizePanelToFit completed from setButtons");
+    EAULOG(@"Eau: sizePanelToFit completed from setButtons");
     isGreen = YES;
     result = NSAlertErrorReturn;
-    NSLog(@"Eau: setButtons completed successfully");
+    EAULOG(@"Eau: setButtons completed successfully");
     }
     @catch (NSException *exception) {
-        NSLog(@"Eau: EXCEPTION in setButtons: %@", exception);
-        NSLog(@"Eau: Exception reason: %@", [exception reason]);
-        NSLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        EAULOG(@"Eau: EXCEPTION in setButtons: %@", exception);
+        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
+        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 
@@ -1183,20 +1183,20 @@ static void setKeyEquivalent(NSButton *button)
     didSwizzle = YES;
     
     EAULOG(@"Eau: Installing NSAlert customizations");
-    // NSLog(@"Eau: Installing NSAlert customizations - FORCED LOG");
+    // EAULOG(@"Eau: Installing NSAlert customizations - FORCED LOG");
     
     // Swizzle NSAlert's _setupPanel to use EauAlertPanel
     Class alertClass = NSClassFromString(@"NSAlert");
     SEL origSetupSel = @selector(_setupPanel);
     SEL swizzledSetupSel = @selector(eau_setupPanel);
     
-    // NSLog(@"Eau: Found NSAlert class: %@", alertClass);
+    // EAULOG(@"Eau: Found NSAlert class: %@", alertClass);
     
     Method origSetupMethod = class_getInstanceMethod(alertClass, origSetupSel);
     Method swizzledSetupMethod = class_getInstanceMethod(alertClass, swizzledSetupSel);
     
-    // NSLog(@"Eau: Original _setupPanel method: %p", origSetupMethod);
-    // NSLog(@"Eau: Swizzled eau_setupPanel method: %p", swizzledSetupMethod);
+    // EAULOG(@"Eau: Original _setupPanel method: %p", origSetupMethod);
+    // EAULOG(@"Eau: Swizzled eau_setupPanel method: %p", swizzledSetupMethod);
     
     if (origSetupMethod && swizzledSetupMethod)
     {
@@ -1216,12 +1216,12 @@ static void setKeyEquivalent(NSButton *button)
             method_exchangeImplementations(origSetupMethod, swizzledSetupMethod);
         }
         EAULOG(@"Eau: NSAlert _setupPanel swizzled successfully");
-        // NSLog(@"Eau: NSAlert _setupPanel swizzled successfully - FORCED LOG");
+        // EAULOG(@"Eau: NSAlert _setupPanel swizzled successfully - FORCED LOG");
     }
     else
     {
         EAULOG(@"Eau: Warning - could not find _setupPanel method to swizzle");
-        // NSLog(@"Eau: Warning - could not find _setupPanel method to swizzle - FORCED LOG");
+        // EAULOG(@"Eau: Warning - could not find _setupPanel method to swizzle - FORCED LOG");
     }
     
     // Swizzle NSAlert's runModal to ensure proper activation
@@ -1293,7 +1293,7 @@ static void setKeyEquivalent(NSButton *button)
 // - Avoids KVC retain/release side effects on _window
 - (NSInteger) eau_runModal
 {
-    NSLog(@"Eau: NSAlert eau_runModal called");
+    EAULOG(@"Eau: NSAlert eau_runModal called");
     @try {
 
     if (![NSThread isMainThread])
@@ -1311,12 +1311,12 @@ static void setKeyEquivalent(NSButton *button)
     
     // Beep when alert is displayed (diagnostics)
     NSApplication *eauApp = [NSApplication sharedApplication];
-    NSLog(@"Eau: NSAlert about to beep - NSApp class: %@ respondsToSelector: %d",
+    EAULOG(@"Eau: NSAlert about to beep - NSApp class: %@ respondsToSelector: %d",
           NSStringFromClass([eauApp class]), (int)[eauApp respondsToSelector:@selector(beep)]);
     if ([eauApp respondsToSelector:@selector(beep)]) {
         [eauApp performSelector:@selector(beep)];
     } else {
-        NSLog(@"Eau: NSApp does not respond to -beep");
+        EAULOG(@"Eau: NSApp does not respond to -beep");
     }
     
     // Get the _window ivar (NSAlert owns the panel instance)
@@ -1420,13 +1420,13 @@ static void setKeyEquivalent(NSButton *button)
     }
     
     // Fallback: if window creation failed, return failure
-    NSLog(@"Eau: NSAlert eau_runModal - window was nil, returning NSAlertFirstButtonReturn");
+    EAULOG(@"Eau: NSAlert eau_runModal - window was nil, returning NSAlertFirstButtonReturn");
     return NSAlertFirstButtonReturn;
     }
     @catch (NSException *exception) {
-        NSLog(@"Eau: FATAL EXCEPTION in eau_runModal: %@", exception);
-        NSLog(@"Eau: Exception reason: %@", [exception reason]);
-        NSLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        EAULOG(@"Eau: FATAL EXCEPTION in eau_runModal: %@", exception);
+        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
+        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
         return NSAlertErrorReturn;
     }
 }
@@ -1434,14 +1434,14 @@ static void setKeyEquivalent(NSButton *button)
 // Cleanup helper to clear NSAlert's window after modal teardown.
 - (void)eau_cleanupPanel
 {
-    NSLog(@"Eau: eau_cleanupPanel called for NSAlert %p", self);
+    EAULOG(@"Eau: eau_cleanupPanel called for NSAlert %p", self);
     Ivar windowIvar = class_getInstanceVariable([self class], "_window");
     if (windowIvar)
     {
         // Check current value
         id currentWindow = object_getIvar(self, windowIvar);
         if (currentWindow) {
-            NSLog(@"Eau: Cleaning up window %p before release", currentWindow);
+            EAULOG(@"Eau: Cleaning up window %p before release", currentWindow);
             @try {
                 // Ensure pulse animation and delegate are cleared while window is still alive
                 if ([currentWindow respondsToSelector: @selector(setDefaultButtonCell:)]) {
@@ -1451,17 +1451,17 @@ static void setKeyEquivalent(NSButton *button)
                     [currentWindow setDelegate: nil];
                 }
             } @catch (NSException *e) {
-                NSLog(@"Eau: Exception during window cleanup: %@", e);
+                EAULOG(@"Eau: Exception during window cleanup: %@", e);
             }
             
-            NSLog(@"Eau: Clearing _window ivar and associated object on NSAlert");
+            EAULOG(@"Eau: Clearing _window ivar and associated object on NSAlert");
             object_setIvar(self, windowIvar, nil);
             objc_setAssociatedObject(self, kEAUAlertWindowRetainKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
     }
     else
     {
-        NSLog(@"Eau: _window ivar not found during cleanup, trying KVC");
+        EAULOG(@"Eau: _window ivar not found during cleanup, trying KVC");
         @try {
             [self setValue: nil forKey: @"_window"];
             objc_setAssociatedObject(self, kEAUAlertWindowRetainKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1476,23 +1476,23 @@ static void setKeyEquivalent(NSButton *button)
 // Builds a themed EauAlertPanel and assigns it to NSAlert's _window ivar.
 - (void) eau_setupPanel
 {
-    NSLog(@"Eau: eau_setupPanel called for NSAlert");
+    EAULOG(@"Eau: eau_setupPanel called for NSAlert");
     
     EauAlertPanel *panel;
     NSString *title;
     
     @try {
-    NSLog(@"Eau: Creating EauAlertPanel");
+    EAULOG(@"Eau: Creating EauAlertPanel");
     panel = [[EauAlertPanel alloc] init];
     if (panel == nil)
     {
-        NSLog(@"Eau: CRITICAL - EauAlertPanel init returned nil");
+        EAULOG(@"Eau: CRITICAL - EauAlertPanel init returned nil");
         return;
     }
-    NSLog(@"Eau: EauAlertPanel created successfully: %@", panel);
+    EAULOG(@"Eau: EauAlertPanel created successfully: %@", panel);
     
     // Access NSAlert's ivars through KVC or accessor methods
-    NSLog(@"Eau: Accessing NSAlert properties");
+    EAULOG(@"Eau: Accessing NSAlert properties");
     NSAlertStyle style = NSWarningAlertStyle;
     NSString *messageText = nil;
     NSString *informativeText = nil;
@@ -1501,43 +1501,43 @@ static void setKeyEquivalent(NSButton *button)
     
     @try {
         style = [self alertStyle];
-        NSLog(@"Eau: alertStyle: %ld", (long)style);
+        EAULOG(@"Eau: alertStyle: %ld", (long)style);
     } @catch (NSException *e) {
-        NSLog(@"Eau: Exception getting alertStyle: %@", e);
+        EAULOG(@"Eau: Exception getting alertStyle: %@", e);
     }
     
     @try {
         messageText = [self messageText];
-        NSLog(@"Eau: messageText: %@", messageText);
+        EAULOG(@"Eau: messageText: %@", messageText);
     } @catch (NSException *e) {
-        NSLog(@"Eau: Exception getting messageText: %@", e);
+        EAULOG(@"Eau: Exception getting messageText: %@", e);
     }
     
     @try {
         informativeText = [self informativeText];
-        NSLog(@"Eau: informativeText: %@", informativeText);
+        EAULOG(@"Eau: informativeText: %@", informativeText);
     } @catch (NSException *e) {
-        NSLog(@"Eau: Exception getting informativeText: %@", e);
+        EAULOG(@"Eau: Exception getting informativeText: %@", e);
     }
     
     @try {
         icon = [self icon];
-        NSLog(@"Eau: icon: %@", icon);
+        EAULOG(@"Eau: icon: %@", icon);
     } @catch (NSException *e) {
-        NSLog(@"Eau: Exception getting icon: %@", e);
+        EAULOG(@"Eau: Exception getting icon: %@", e);
     }
     
     @try {
         buttons = [self buttons];
-        NSLog(@"Eau: buttons count: %lu", (unsigned long)[buttons count]);
+        EAULOG(@"Eau: buttons count: %lu", (unsigned long)[buttons count]);
     } @catch (NSException *e) {
-        NSLog(@"Eau: Exception getting buttons: %@", e);
+        EAULOG(@"Eau: Exception getting buttons: %@", e);
     }
     
     // Set default icons based on alert style if no custom icon is provided
     if (icon == nil)
     {
-        NSLog(@"Eau: No icon provided, using default for style %ld", (long)style);
+        EAULOG(@"Eau: No icon provided, using default for style %ld", (long)style);
         @try {
             switch (style)
             {
@@ -1553,9 +1553,9 @@ static void setKeyEquivalent(NSButton *button)
                     break;
             }
             if (icon != nil)
-                NSLog(@"Eau: Loaded default icon: %@", icon);
+                EAULOG(@"Eau: Loaded default icon: %@", icon);
         } @catch (NSException *e) {
-            NSLog(@"Eau: Exception loading default icon: %@", e);
+            EAULOG(@"Eau: Exception loading default icon: %@", e);
         }
     }
     
@@ -1573,60 +1573,60 @@ static void setKeyEquivalent(NSButton *button)
             break;
     }
     
-    NSLog(@"Eau: Setting up panel with title and buttons");
+    EAULOG(@"Eau: Setting up panel with title and buttons");
     @try {
         [panel setTitleBar: title
                       icon: icon
                      title: messageText != nil ? messageText : @"Alert"
                    message: informativeText != nil ? informativeText : @""];
-        NSLog(@"Eau: setTitleBar completed");
+        EAULOG(@"Eau: setTitleBar completed");
     } @catch (NSException *e) {
-        NSLog(@"Eau: EXCEPTION in setTitleBar: %@", e);
+        EAULOG(@"Eau: EXCEPTION in setTitleBar: %@", e);
     }
     
     @try {
         if ([buttons count] == 0)
         {
-            NSLog(@"Eau: No buttons, adding default OK button");
+            EAULOG(@"Eau: No buttons, adding default OK button");
             [self addButtonWithTitle: @"OK"];
             buttons = [self buttons];
         }
         
-        NSLog(@"Eau: Setting %lu buttons on panel", (unsigned long)[buttons count]);
+        EAULOG(@"Eau: Setting %lu buttons on panel", (unsigned long)[buttons count]);
         [panel setButtons: buttons];
-        NSLog(@"Eau: setButtons completed");
+        EAULOG(@"Eau: setButtons completed");
     } @catch (NSException *e) {
-        NSLog(@"Eau: EXCEPTION in setButtons: %@", e);
+        EAULOG(@"Eau: EXCEPTION in setButtons: %@", e);
     }
     
     // Set the _window ivar directly when possible to avoid KVC retain/release side effects
-    NSLog(@"Eau: Setting _window ivar on NSAlert");
+    EAULOG(@"Eau: Setting _window ivar on NSAlert");
     {
         Ivar windowIvar = class_getInstanceVariable([self class], "_window");
         if (windowIvar)
         {
             object_setIvar(self, windowIvar, panel);
             objc_setAssociatedObject(self, kEAUAlertWindowRetainKey, panel, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            NSLog(@"Eau: Successfully set _window via ivar");
+            EAULOG(@"Eau: Successfully set _window via ivar");
         }
         else
         {
             @try {
                 [self setValue: panel forKey: @"_window"];
-                NSLog(@"Eau: Successfully set _window via KVC");
+                EAULOG(@"Eau: Successfully set _window via KVC");
             }
             @catch (NSException *exception) {
-                NSLog(@"Eau: CRITICAL - could not set _window ivar on NSAlert: %@", exception);
+                EAULOG(@"Eau: CRITICAL - could not set _window ivar on NSAlert: %@", exception);
             }
         }
     }
     
-    NSLog(@"Eau: eau_setupPanel completed successfully");
+    EAULOG(@"Eau: eau_setupPanel completed successfully");
     }
     @catch (NSException *exception) {
-        NSLog(@"Eau: FATAL EXCEPTION in eau_setupPanel: %@", exception);
-        NSLog(@"Eau: Exception reason: %@", [exception reason]);
-        NSLog(@"Eau: Exception stack: %@", [exception callStackSymbols]);
+        EAULOG(@"Eau: FATAL EXCEPTION in eau_setupPanel: %@", exception);
+        EAULOG(@"Eau: Exception reason: %@", [exception reason]);
+        EAULOG(@"Eau: Exception stack: %@", [exception callStackSymbols]);
     }
 }
 

--- a/NSBeep+Eau.m
+++ b/NSBeep+Eau.m
@@ -13,7 +13,7 @@
 @implementation NSApplication (EauBeep)
 
 + (void)load {
-    EAULOG(@"NSApplication(EauBeep) +load");
+    NSDebugLog(@"NSApplication(EauBeep) +load");
 }
 
 
@@ -24,27 +24,27 @@
     
     // Prevent recursive calls
     if (isPlaying) {
-        EAULOG(@"Re-entrant beep ignored");
+        NSDebugLog(@"Re-entrant beep ignored");
         return;
     }
     
     isPlaying = YES;
-    EAULOG(@"-beep called");
+    NSDebugLog(@"-beep called");
     
     @autoreleasepool {
         // Load preferences for alert sound
         NSString *prefsPath = [NSHomeDirectory() stringByAppendingPathComponent:
                               @".config/gershwin/sound-defaults.plist"];
-        EAULOG(@"prefsPath: %@", prefsPath);
+        NSDebugLog(@"prefsPath: %@", prefsPath);
         
         NSDictionary *prefs = [NSDictionary dictionaryWithContentsOfFile:prefsPath];
         
         if (prefs) {
-            EAULOG(@"Loaded prefs");
+            NSDebugLog(@"Loaded prefs");
             NSString *alertSoundName = [prefs objectForKey:@"alertSound"];
             
             if (alertSoundName) {
-                EAULOG(@"alertSound: %@", alertSoundName);
+                NSDebugLog(@"alertSound: %@", alertSoundName);
                 // Search for the sound file
                 NSArray *soundPaths = @[
                     @"/System/Library/Sounds",
@@ -61,31 +61,31 @@
                                              [alertSoundName stringByAppendingPathExtension:ext]];
                         
                         if ([[NSFileManager defaultManager] fileExistsAtPath:soundPath]) {
-                            EAULOG(@"Found sound at %@", soundPath);
+                            NSDebugLog(@"Found sound at %@", soundPath);
                             // Play the sound using NSSound
                             NSSound *sound = [[NSSound alloc] initWithContentsOfFile:soundPath
                                                                         byReference:YES];
                             if (sound) {
-                                EAULOG(@"Playing sound %@", soundPath);
+                                NSDebugLog(@"Playing sound %@", soundPath);
                                 [sound play];
                                 isPlaying = NO;
                                 return;
                             } else {
-                                EAULOG(@"Failed to init NSSound for %@", soundPath);
+                                NSDebugLog(@"Failed to init NSSound for %@", soundPath);
                             }
                         }
                     }
                 }
-                EAULOG(@"No sound file found for %@ in sound paths", alertSoundName);
+                NSDebugLog(@"No sound file found for %@ in sound paths", alertSoundName);
             } else {
-                EAULOG(@"alertSound key missing in prefs");
+                NSDebugLog(@"alertSound key missing in prefs");
             }
         } else {
-            EAULOG(@"No prefs found at %@", prefsPath);
+            NSDebugLog(@"No prefs found at %@", prefsPath);
         }
         
         // Fall back to system beep (PC speaker or /dev/console)
-        EAULOG(@"Falling back to system bell");
+        NSDebugLog(@"Falling back to system bell");
         printf("\a");
         fflush(stdout);
     }

--- a/NSBox+Eau.m
+++ b/NSBox+Eau.m
@@ -16,13 +16,13 @@
 
 @implementation Eau(NSBox)
 - (void) _overrideNSBoxMethod_drawRect: (NSRect)rect {
-  EAULOG(@"_overrideNSBoxMethod_drawRect:");
+  NSDebugLog(@"_overrideNSBoxMethod_drawRect:");
   NSBox* xself = (NSBox*)self;
   [xself EAUdrawRect:rect];
 }
 
 - (NSRect) _overrideNSBoxMethod_calcSizesAllowingNegative: (BOOL)aFlag {
-  EAULOG(@"_overrideNSBoxMethod_calcSizesAllowingNegative:");
+  NSDebugLog(@"_overrideNSBoxMethod_calcSizesAllowingNegative:");
   NSBox* xself = (NSBox*)self;
   return [xself EAUcalcSizesAllowingNegative:aFlag];
 }

--- a/NSBrowserCell+Eau.m
+++ b/NSBrowserCell+Eau.m
@@ -6,7 +6,7 @@
 
 @implementation Eau(NSBrowserCell)
 - (void) _overrideNSBrowserCellMethod_drawInteriorWithFrame: (NSRect)cellFrame inView: (NSView *)controlView {
-  EAULOG(@"_overrideNSBrowserCellMethod_drawInteriorWithFrame:inView:");
+  NSDebugLog(@"_overrideNSBrowserCellMethod_drawInteriorWithFrame:inView:");
   NSBrowserCell *xself = (NSBrowserCell*)self;
   [xself EAUdrawInteriorWithFrame:cellFrame inView:controlView];
 }

--- a/NSButtonCell+Eau.m
+++ b/NSButtonCell+Eau.m
@@ -66,7 +66,7 @@
 - (void)EAU_drawAtPoint:(NSPoint)point
 {
   if ([self EAU_isReturnImage]) {
-    EAULOG(@"NSImage: Suppressing drawAtPoint for %@", [self name]);
+    NSDebugLog(@"NSImage: Suppressing drawAtPoint for %@", [self name]);
     return;
   }
   [self EAU_drawAtPoint:point];
@@ -75,7 +75,7 @@
 - (void)EAU_drawInRect:(NSRect)rect
 {
   if ([self EAU_isReturnImage]) {
-    EAULOG(@"NSImage: Suppressing drawInRect for %@", [self name]);
+    NSDebugLog(@"NSImage: Suppressing drawInRect for %@", [self name]);
     return;
   }
   [self EAU_drawInRect:rect];
@@ -84,7 +84,7 @@
 - (void)EAU_drawInRect:(NSRect)rect fromRect:(NSRect)srcRect operation:(NSCompositingOperation)op fraction:(CGFloat)delta
 {
   if ([self EAU_isReturnImage]) {
-    EAULOG(@"NSImage: Suppressing drawInRect:fromRect:operation:fraction: for %@", [self name]);
+    NSDebugLog(@"NSImage: Suppressing drawInRect:fromRect:operation:fraction: for %@", [self name]);
     return;
   }
   [self EAU_drawInRect:rect fromRect:srcRect operation:op fraction:delta];
@@ -93,7 +93,7 @@
 - (void)EAU_drawInRect:(NSRect)rect fromRect:(NSRect)srcRect operation:(NSCompositingOperation)op fraction:(CGFloat)delta respectFlipped:(BOOL)respectFlipped hints:(NSDictionary *)hints
 {
   if ([self EAU_isReturnImage]) {
-    EAULOG(@"NSImage: Suppressing drawInRect:respectFlipped:hints: for %@", [self name]);
+    NSDebugLog(@"NSImage: Suppressing drawInRect:respectFlipped:hints: for %@", [self name]);
     return;
   }
   [self EAU_drawInRect:rect fromRect:srcRect operation:op fraction:delta respectFlipped:respectFlipped hints:hints];
@@ -139,7 +139,7 @@ static NSMutableSet *returnImageCells = nil;
     if (orig && swiz) method_exchangeImplementations(orig, swiz);
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR swizzling drawInteriorWithFrame: %@", exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR swizzling drawInteriorWithFrame: %@", exception);
   }
 }
 
@@ -299,60 +299,60 @@ static NSMutableSet *returnImageCells = nil;
 // Enable pulsing animation for default buttons and make them selected
 - (void) enablePulsing
 {
-  EAULOG(@"NSButtonCell+Eau: enablePulsing called for button cell %p", self);
+  NSDebugLog(@"NSButtonCell+Eau: enablePulsing called for button cell %p", self);
   
   @try {
     // Prevent multiple enablePulsing calls for the same cell
     @synchronized(defaultButtonSetCells) {
       NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
       if ([defaultButtonSetCells containsObject:cellPtr]) {
-        EAULOG(@"NSButtonCell+Eau: Button cell %p already enabled for pulsing, skipping", self);
+        NSDebugLog(@"NSButtonCell+Eau: Button cell %p already enabled for pulsing, skipping", self);
         return;
       }
     }
     
-    EAULOG(@"NSButtonCell+Eau: Setting button cell %p as default button", self);
+    NSDebugLog(@"NSButtonCell+Eau: Setting button cell %p as default button", self);
     [self setIsDefaultButton:@YES];
     
-    EAULOG(@"NSButtonCell+Eau: Making button cell %p selected and highlighted", self);
+    NSDebugLog(@"NSButtonCell+Eau: Making button cell %p selected and highlighted", self);
     [self safelyMakeButtonSelectedAndHighlighted];
     
-    EAULOG(@"NSButtonCell+Eau: Starting strategy to set default button for cell %p", self);
+    NSDebugLog(@"NSButtonCell+Eau: Starting strategy to set default button for cell %p", self);
     [self trySetAsDefaultButtonWithStrategy];
     
-    EAULOG(@"NSButtonCell+Eau: enablePulsing completed successfully for button cell %p", self);
+    NSDebugLog(@"NSButtonCell+Eau: enablePulsing completed successfully for button cell %p", self);
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in enablePulsing for button cell %p: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in enablePulsing for button cell %p: %@", self, exception);
   }
 }
 
 // Try multiple strategies to find the window and set default button
 - (void) trySetAsDefaultButtonWithStrategy
 {
-  EAULOG(@"NSButtonCell+Eau: trySetAsDefaultButtonWithStrategy called for button cell %p", self);
+  NSDebugLog(@"NSButtonCell+Eau: trySetAsDefaultButtonWithStrategy called for button cell %p", self);
   
   @try {
     // Prevent multiple attempts for the same cell
     @synchronized(defaultButtonSetCells) {
       NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
       if ([defaultButtonSetCells containsObject:cellPtr]) {
-        EAULOG(@"NSButtonCell+Eau: Button cell %p already processed, skipping", self);
+        NSDebugLog(@"NSButtonCell+Eau: Button cell %p already processed, skipping", self);
         return;
       }
     }
     
     // Try immediate window access
-    EAULOG(@"NSButtonCell+Eau: Trying direct window access for button cell %p", self);
+    NSDebugLog(@"NSButtonCell+Eau: Trying direct window access for button cell %p", self);
     if ([self tryDirectWindowAccess]) {
-      EAULOG(@"NSButtonCell+Eau: Direct window access succeeded for button cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Direct window access succeeded for button cell %p", self);
       return;
     }
     
     // Search all windows for this button cell
-    EAULOG(@"NSButtonCell+Eau: Trying to search all windows for button cell %p", self);
+    NSDebugLog(@"NSButtonCell+Eau: Trying to search all windows for button cell %p", self);
     if ([self trySearchAllWindows]) {
-      EAULOG(@"NSButtonCell+Eau: Window search succeeded for button cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Window search succeeded for button cell %p", self);
       return;
     }
     
@@ -363,7 +363,7 @@ static NSMutableSet *returnImageCells = nil;
       controlView = [self controlView];
     }
     if (!controlView || ![controlView isKindOfClass:[NSView class]]) {
-      EAULOG(@"NSButtonCell+Eau: Control view missing or invalid, skipping delayed attempt for cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Control view missing or invalid, skipping delayed attempt for cell %p", self);
       return;
     }
 
@@ -371,52 +371,52 @@ static NSMutableSet *returnImageCells = nil;
     @try {
       window = [controlView window];
     } @catch (NSException *windowException) {
-      EAULOG(@"NSButtonCell+Eau: Exception getting window for cell %p: %@", self, windowException);
+      NSDebugLog(@"NSButtonCell+Eau: Exception getting window for cell %p: %@", self, windowException);
       return;
     }
 
     if (!window || ![window isKindOfClass:[NSWindow class]]) {
-      EAULOG(@"NSButtonCell+Eau: Window missing or invalid, skipping delayed attempt for cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Window missing or invalid, skipping delayed attempt for cell %p", self);
       return;
     }
 
     // Skip delayed attempts for panels (short-lived)
     if ([window isKindOfClass:[NSPanel class]]) {
-      EAULOG(@"NSButtonCell+Eau: Button is in a panel, skipping delayed attempt for cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Button is in a panel, skipping delayed attempt for cell %p", self);
       return;
     }
 
     // Skip delayed attempts for modal windows (short-lived, closed when modal session ends)
     if ([NSApp modalWindow] == window) {
-      EAULOG(@"NSButtonCell+Eau: Button is in modal window, skipping delayed attempt for cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Button is in modal window, skipping delayed attempt for cell %p", self);
       return;
     }
     
     // Only schedule ONE delayed attempt to prevent loops
-    EAULOG(@"NSButtonCell+Eau: Scheduling single delayed attempt for button cell %p", self);
+    NSDebugLog(@"NSButtonCell+Eau: Scheduling single delayed attempt for button cell %p", self);
     @try {
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [self finalAttemptSetAsDefaultButton];
       });
     }
     @catch (NSException *performException) {
-      EAULOG(@"NSButtonCell+Eau: ERROR scheduling delayed attempt for cell %p: %@", self, performException);
+      NSDebugLog(@"NSButtonCell+Eau: ERROR scheduling delayed attempt for cell %p: %@", self, performException);
     }
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in trySetAsDefaultButtonWithStrategy for cell %p: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in trySetAsDefaultButtonWithStrategy for cell %p: %@", self, exception);
   }
 }
 
 // Final attempt to set as default button (only called once)
 - (void) finalAttemptSetAsDefaultButton
 {
-  EAULOG(@"NSButtonCell+Eau: finalAttemptSetAsDefaultButton called for button cell %p", self);
+  NSDebugLog(@"NSButtonCell+Eau: finalAttemptSetAsDefaultButton called for button cell %p", self);
   
   @try {
     // Defensive: Verify self is still a valid object
     if (![self isKindOfClass:[NSButtonCell class]]) {
-      EAULOG(@"NSButtonCell+Eau: Cell %p is no longer valid, aborting final attempt", self);
+      NSDebugLog(@"NSButtonCell+Eau: Cell %p is no longer valid, aborting final attempt", self);
       return;
     }
     
@@ -425,24 +425,24 @@ static NSMutableSet *returnImageCells = nil;
     NSWindow *window = nil;
     
     if (![self respondsToSelector:@selector(controlView)]) {
-      EAULOG(@"NSButtonCell+Eau: Cell does not respond to controlView, aborting");
+      NSDebugLog(@"NSButtonCell+Eau: Cell does not respond to controlView, aborting");
       return;
     }
     
     controlView = [self controlView];
     if (!controlView) {
-      EAULOG(@"NSButtonCell+Eau: Control view is nil in final attempt for cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Control view is nil in final attempt for cell %p", self);
       return;
     }
     
     // Validate controlView is actually a view before accessing it
     if (![controlView respondsToSelector:@selector(window)]) {
-      EAULOG(@"NSButtonCell+Eau: Control view does not respond to window selector, aborting");
+      NSDebugLog(@"NSButtonCell+Eau: Control view does not respond to window selector, aborting");
       return;
     }
     
     if (![controlView isKindOfClass:[NSView class]]) {
-      EAULOG(@"NSButtonCell+Eau: Control view is not an NSView in final attempt for cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Control view is not an NSView in final attempt for cell %p", self);
       return;
     }
     
@@ -450,17 +450,17 @@ static NSMutableSet *returnImageCells = nil;
     @try {
       window = [controlView window];
     } @catch (NSException *windowException) {
-      EAULOG(@"NSButtonCell+Eau: Exception getting window from control view for cell %p: %@", self, windowException);
+      NSDebugLog(@"NSButtonCell+Eau: Exception getting window from control view for cell %p: %@", self, windowException);
       return;
     }
     
     if (!window) {
-      EAULOG(@"NSButtonCell+Eau: Window is nil in final attempt for cell %p (window closed or view detached)", self);
+      NSDebugLog(@"NSButtonCell+Eau: Window is nil in final attempt for cell %p (window closed or view detached)", self);
       return;
     }
     
     if (![window isKindOfClass:[NSWindow class]]) {
-      EAULOG(@"NSButtonCell+Eau: Window is not an NSWindow in final attempt for cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Window is not an NSWindow in final attempt for cell %p", self);
       return;
     }
     
@@ -469,12 +469,12 @@ static NSMutableSet *returnImageCells = nil;
     @try {
       isVisible = [window isVisible];
     } @catch (NSException *visException) {
-      EAULOG(@"NSButtonCell+Eau: Exception checking window visibility for cell %p: %@", self, visException);
+      NSDebugLog(@"NSButtonCell+Eau: Exception checking window visibility for cell %p: %@", self, visException);
       return;
     }
     
     if (!isVisible) {
-      EAULOG(@"NSButtonCell+Eau: Window is not visible in final attempt for cell %p, aborting", self);
+      NSDebugLog(@"NSButtonCell+Eau: Window is not visible in final attempt for cell %p, aborting", self);
       return;
     }
     
@@ -482,27 +482,27 @@ static NSMutableSet *returnImageCells = nil;
     @synchronized(defaultButtonSetCells) {
       NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
       if ([defaultButtonSetCells containsObject:cellPtr]) {
-        EAULOG(@"NSButtonCell+Eau: Button cell %p already processed in final attempt", self);
+        NSDebugLog(@"NSButtonCell+Eau: Button cell %p already processed in final attempt", self);
         return;
       }
     }
     
     // Try one more time with direct access
     if ([self tryDirectWindowAccess]) {
-      EAULOG(@"NSButtonCell+Eau: Final direct window access succeeded for button cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Final direct window access succeeded for button cell %p", self);
       return;
     }
     
     // Try one more time with window search
     if ([self trySearchAllWindows]) {
-      EAULOG(@"NSButtonCell+Eau: Final window search succeeded for button cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Final window search succeeded for button cell %p", self);
       return;
     }
     
-    EAULOG(@"NSButtonCell+Eau: Final attempt failed for button cell %p - giving up", self);
+    NSDebugLog(@"NSButtonCell+Eau: Final attempt failed for button cell %p - giving up", self);
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in finalAttemptSetAsDefaultButton for cell %p: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in finalAttemptSetAsDefaultButton for cell %p: %@", self, exception);
   }
 }
 
@@ -519,7 +519,7 @@ static NSMutableSet *returnImageCells = nil;
   }
 
   if (hasReturnImage && [self isHighlighted]) {
-    EAULOG(@"NSButtonCell+Eau: Suppressing layout image space for highlighted cell %p (return image), title rect adjusted", self);
+    NSDebugLog(@"NSButtonCell+Eau: Suppressing layout image space for highlighted cell %p (return image), title rect adjusted", self);
     NSRect frame = [self drawingRectForBounds: theRect];
     if ([self isBordered] || [self isBezeled]) {
       frame.origin.x += 3;
@@ -536,18 +536,18 @@ static NSMutableSet *returnImageCells = nil;
 // Strategy 1: Try direct window access through controlView
 - (BOOL) tryDirectWindowAccess
 {
-  EAULOG(@"NSButtonCell+Eau: tryDirectWindowAccess called for button cell %p", self);
+  NSDebugLog(@"NSButtonCell+Eau: tryDirectWindowAccess called for button cell %p", self);
   
   @try {
     NSView *controlView = nil;
     if ([self respondsToSelector:@selector(controlView)]) {
       controlView = [self controlView];
-      EAULOG(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
+      NSDebugLog(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
     }
     
     // Defensive: Check if controlView is still valid (not deallocated)
     if (!controlView || ![controlView isKindOfClass:[NSView class]]) {
-      EAULOG(@"NSButtonCell+Eau: Control view is nil or invalid for button cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: Control view is nil or invalid for button cell %p", self);
       return NO;
     }
     
@@ -556,15 +556,15 @@ static NSMutableSet *returnImageCells = nil;
     if (controlView) {
       @try {
         window = [controlView window];
-        EAULOG(@"NSButtonCell+Eau: Found window %p for control view %p", window, controlView);
+        NSDebugLog(@"NSButtonCell+Eau: Found window %p for control view %p", window, controlView);
       }
       @catch (NSException *windowException) {
-        EAULOG(@"NSButtonCell+Eau: ERROR getting window from control view %p: %@", controlView, windowException);
+        NSDebugLog(@"NSButtonCell+Eau: ERROR getting window from control view %p: %@", controlView, windowException);
       }
       
       if (!window) {
         // Try to find window by traversing the view hierarchy
-        EAULOG(@"NSButtonCell+Eau: Traversing view hierarchy to find window for control view %p", controlView);
+        NSDebugLog(@"NSButtonCell+Eau: Traversing view hierarchy to find window for control view %p", controlView);
         NSView *currentView = controlView;
         while (currentView && !window) {
           @try {
@@ -573,7 +573,7 @@ static NSMutableSet *returnImageCells = nil;
             if (currentView && [currentView isKindOfClass:[NSView class]]) {
               window = [currentView window];
               if (window) {
-                EAULOG(@"NSButtonCell+Eau: Found window %p through view hierarchy traversal", window);
+                NSDebugLog(@"NSButtonCell+Eau: Found window %p through view hierarchy traversal", window);
               }
             } else {
               // Invalid view in hierarchy, stop traversing
@@ -581,7 +581,7 @@ static NSMutableSet *returnImageCells = nil;
             }
           }
           @catch (NSException *hierarchyException) {
-            EAULOG(@"NSButtonCell+Eau: ERROR traversing view hierarchy: %@", hierarchyException);
+            NSDebugLog(@"NSButtonCell+Eau: ERROR traversing view hierarchy: %@", hierarchyException);
             break;
           }
         }
@@ -591,27 +591,27 @@ static NSMutableSet *returnImageCells = nil;
       if (window && [window isKindOfClass:[NSWindow class]]) {
         @try {
           [self markAsDefaultButtonSet];
-          EAULOG(@"NSButtonCell+Eau: Setting window %p default button cell to %p", window, self);
+          NSDebugLog(@"NSButtonCell+Eau: Setting window %p default button cell to %p", window, self);
           [window setDefaultButtonCell:self];
           
           // Also make the button visually selected/highlighted
           [self safelyMakeButtonSelectedAndHighlighted];
           
-          EAULOG(@"NSButtonCell+Eau: Successfully set default button cell for window %p", window);
+          NSDebugLog(@"NSButtonCell+Eau: Successfully set default button cell for window %p", window);
           return YES;
         }
         @catch (NSException *setDefaultException) {
-          EAULOG(@"NSButtonCell+Eau: ERROR setting default button cell for window %p: %@", window, setDefaultException);
+          NSDebugLog(@"NSButtonCell+Eau: ERROR setting default button cell for window %p: %@", window, setDefaultException);
         }
       } else {
-        EAULOG(@"NSButtonCell+Eau: No window found for control view %p", controlView);
+        NSDebugLog(@"NSButtonCell+Eau: No window found for control view %p", controlView);
       }
     } else {
-      EAULOG(@"NSButtonCell+Eau: No control view found for button cell %p", self);
+      NSDebugLog(@"NSButtonCell+Eau: No control view found for button cell %p", self);
     }
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in tryDirectWindowAccess for cell %p: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in tryDirectWindowAccess for cell %p: %@", self, exception);
   }
   
   return NO;
@@ -637,7 +637,7 @@ static NSMutableSet *returnImageCells = nil;
       [self setImagePosition: NSNoImage];
     }
     @catch (NSException *e) {
-      EAULOG(@"NSButtonCell+Eau: ERROR setting imagePosition to NSNoImage for cell %p: %@", self, e);
+      NSDebugLog(@"NSButtonCell+Eau: ERROR setting imagePosition to NSNoImage for cell %p: %@", self, e);
       shouldRemoveImagePosition = NO; // avoid restoring to wrong state
     }
   }
@@ -647,7 +647,7 @@ static NSMutableSet *returnImageCells = nil;
     [self EAU_drawInteriorWithFrame:cellFrame inView:controlView];
   }
   @catch (NSException *e) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in EAU_drawInteriorWithFrame (original): %@", e);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in EAU_drawInteriorWithFrame (original): %@", e);
   }
 
   if (shouldRemoveImagePosition) {
@@ -655,7 +655,7 @@ static NSMutableSet *returnImageCells = nil;
       [self setImagePosition: oldPos];
     }
     @catch (NSException *e) {
-      EAULOG(@"NSButtonCell+Eau: ERROR restoring imagePosition for cell %p: %@", self, e);
+      NSDebugLog(@"NSButtonCell+Eau: ERROR restoring imagePosition for cell %p: %@", self, e);
     }
   }
 }
@@ -663,43 +663,43 @@ static NSMutableSet *returnImageCells = nil;
 // Strategy 2: Search all windows for this button cell
 - (BOOL) trySearchAllWindows
 {
-  EAULOG(@"NSButtonCell+Eau: trySearchAllWindows called for button cell %p", self);
+  NSDebugLog(@"NSButtonCell+Eau: trySearchAllWindows called for button cell %p", self);
   
   @try {
     NSArray *windows = nil;
     if ([NSApp respondsToSelector:@selector(windows)]) {
       windows = [NSApp windows];
-      EAULOG(@"NSButtonCell+Eau: Found %lu windows to search", (unsigned long)[windows count]);
+      NSDebugLog(@"NSButtonCell+Eau: Found %lu windows to search", (unsigned long)[windows count]);
     } else {
-      EAULOG(@"NSButtonCell+Eau: NSApp does not respond to windows selector");
+      NSDebugLog(@"NSButtonCell+Eau: NSApp does not respond to windows selector");
       return NO;
     }
     
     for (NSWindow *candidateWindow in windows) {
       @try {
-        EAULOG(@"NSButtonCell+Eau: Searching window %p for button cell %p", candidateWindow, self);
+        NSDebugLog(@"NSButtonCell+Eau: Searching window %p for button cell %p", candidateWindow, self);
         if ([self findButtonWithCellInWindow:candidateWindow]) {
-          EAULOG(@"NSButtonCell+Eau: Found button cell %p in window %p", self, candidateWindow);
+          NSDebugLog(@"NSButtonCell+Eau: Found button cell %p in window %p", self, candidateWindow);
           [self markAsDefaultButtonSet];
           [candidateWindow setDefaultButtonCell:self];
           
           // Also make the button visually selected/highlighted
           [self safelyMakeButtonSelectedAndHighlighted];
           
-          EAULOG(@"NSButtonCell+Eau: Successfully set default button cell for window %p", candidateWindow);
+          NSDebugLog(@"NSButtonCell+Eau: Successfully set default button cell for window %p", candidateWindow);
           return YES;
         }
       }
       @catch (NSException *windowSearchException) {
-        EAULOG(@"NSButtonCell+Eau: ERROR searching window %p: %@", candidateWindow, windowSearchException);
+        NSDebugLog(@"NSButtonCell+Eau: ERROR searching window %p: %@", candidateWindow, windowSearchException);
         continue;
       }
     }
     
-    EAULOG(@"NSButtonCell+Eau: Button cell %p not found in any of %lu windows", self, (unsigned long)[windows count]);
+    NSDebugLog(@"NSButtonCell+Eau: Button cell %p not found in any of %lu windows", self, (unsigned long)[windows count]);
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in trySearchAllWindows for cell %p: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in trySearchAllWindows for cell %p: %@", self, exception);
   }
   
   return NO;
@@ -712,11 +712,11 @@ static NSMutableSet *returnImageCells = nil;
     @synchronized(defaultButtonSetCells) {
       NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
       [defaultButtonSetCells addObject:cellPtr];
-      EAULOG(@"NSButtonCell+Eau: Marked button cell %p as default button set", self);
+      NSDebugLog(@"NSButtonCell+Eau: Marked button cell %p as default button set", self);
     }
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR marking button cell %p as default: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR marking button cell %p as default: %@", self, exception);
   }
 }
 
@@ -730,7 +730,7 @@ static NSMutableSet *returnImageCells = nil;
     }
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR finding button in window %p: %@", window, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR finding button in window %p: %@", window, exception);
   }
   return NO;
 }
@@ -741,7 +741,7 @@ static NSMutableSet *returnImageCells = nil;
     if ([view isKindOfClass:[NSButton class]]) {
       NSButton *button = (NSButton*)view;
       if ([button cell] == self) {
-        EAULOG(@"NSButtonCell+Eau: Found matching button %p for cell %p", button, self);
+        NSDebugLog(@"NSButtonCell+Eau: Found matching button %p for cell %p", button, self);
         return YES;
       }
     }
@@ -757,7 +757,7 @@ static NSMutableSet *returnImageCells = nil;
     }
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR searching view %p: %@", view, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR searching view %p: %@", view, exception);
   }
   
   return NO;
@@ -766,18 +766,18 @@ static NSMutableSet *returnImageCells = nil;
 // Safely make the button selected and highlighted with extensive error handling
 - (void) safelyMakeButtonSelectedAndHighlighted
 {
-  EAULOG(@"NSButtonCell+Eau: safelyMakeButtonSelectedAndHighlighted called for button cell %p", self);
+  NSDebugLog(@"NSButtonCell+Eau: safelyMakeButtonSelectedAndHighlighted called for button cell %p", self);
   
   @try {
     // DON'T set the cell as highlighted permanently - this interferes with pressed state detection
     // The default button appearance will come from the pulsing animation instead
-    EAULOG(@"NSButtonCell+Eau: Skipping setHighlighted to allow proper pressed state detection");
+    NSDebugLog(@"NSButtonCell+Eau: Skipping setHighlighted to allow proper pressed state detection");
     
     // DON'T set setShowsFirstResponder to avoid interfering with text field focus
 
   }
   @catch (NSException *cellException) {
-    EAULOG(@"NSButtonCell+Eau: ERROR setting cell %p properties: %@", self, cellException);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR setting cell %p properties: %@", self, cellException);
   }
     
   // Try to get the control view safely
@@ -785,70 +785,70 @@ static NSMutableSet *returnImageCells = nil;
   @try {
     if ([self respondsToSelector:@selector(controlView)]) {
       controlView = [self controlView];
-      EAULOG(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
+      NSDebugLog(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
     } else {
-      EAULOG(@"NSButtonCell+Eau: Button cell %p does not respond to controlView selector", self);
+      NSDebugLog(@"NSButtonCell+Eau: Button cell %p does not respond to controlView selector", self);
     }
     
     if (controlView && [controlView isKindOfClass:[NSButton class]]) {
       NSButton *button = (NSButton *)controlView;
-      EAULOG(@"NSButtonCell+Eau: Control view is NSButton %p for cell %p", button, self);
+      NSDebugLog(@"NSButtonCell+Eau: Control view is NSButton %p for cell %p", button, self);
       
       // Make the button highlighted with crash protection but without taking focus
       @try {
 
         
         // Set as key equivalent for Enter/Return key handling but don't take focus
-        EAULOG(@"NSButtonCell+Eau: Setting button %p properties for Return key handling", button);
+        NSDebugLog(@"NSButtonCell+Eau: Setting button %p properties for Return key handling", button);
         
         // Try to set as key equivalent if possible
         if ([button respondsToSelector:@selector(setKeyEquivalent:)]) {
-          EAULOG(@"NSButtonCell+Eau: Setting button %p key equivalent to return", button);
+          NSDebugLog(@"NSButtonCell+Eau: Setting button %p key equivalent to return", button);
           [button setKeyEquivalent:@"\r"];
         }
         
         // DON'T force the button cell to be highlighted - this interferes with pressed state detection
         // The default button appearance will come from the pulsing animation instead
-        EAULOG(@"NSButtonCell+Eau: Skipping setHighlighted to preserve pressed state detection");
+        NSDebugLog(@"NSButtonCell+Eau: Skipping setHighlighted to preserve pressed state detection");
         
         // Force the button to redraw to show changes
-        EAULOG(@"NSButtonCell+Eau: Marking button %p as needing display", button);
+        NSDebugLog(@"NSButtonCell+Eau: Marking button %p as needing display", button);
         [button setNeedsDisplay:YES];
         
         // Make this button the first responder ONLY if the current first responder is already a button
         NSWindow *window = [button window];
         if (window) {
           NSResponder *currentFirstResponder = [window firstResponder];
-          EAULOG(@"NSButtonCell+Eau: Current first responder: %p (class: %@)", currentFirstResponder, [currentFirstResponder class]);
+          NSDebugLog(@"NSButtonCell+Eau: Current first responder: %p (class: %@)", currentFirstResponder, [currentFirstResponder class]);
           
           if (currentFirstResponder && [currentFirstResponder isKindOfClass:[NSButton class]]) {
-            EAULOG(@"NSButtonCell+Eau: Current first responder is a button, making default button %p first responder", button);
+            NSDebugLog(@"NSButtonCell+Eau: Current first responder is a button, making default button %p first responder", button);
             [window makeFirstResponder:button];
           } else {
-            EAULOG(@"NSButtonCell+Eau: Current first responder is not a button (%@), preserving focus", [currentFirstResponder class]);
+            NSDebugLog(@"NSButtonCell+Eau: Current first responder is not a button (%@), preserving focus", [currentFirstResponder class]);
           }
         } else {
-          EAULOG(@"NSButtonCell+Eau: No window found for button %p", button);
+          NSDebugLog(@"NSButtonCell+Eau: No window found for button %p", button);
         }
         
-        EAULOG(@"NSButtonCell+Eau: Successfully configured button %p with conditional focus", button);
+        NSDebugLog(@"NSButtonCell+Eau: Successfully configured button %p with conditional focus", button);
       }
       @catch (NSException *buttonException) {
-        EAULOG(@"NSButtonCell+Eau: ERROR setting button %p properties: %@", button, buttonException);
+        NSDebugLog(@"NSButtonCell+Eau: ERROR setting button %p properties: %@", button, buttonException);
       }
     } else {
-      EAULOG(@"NSButtonCell+Eau: Control view %p is not an NSButton or is nil for cell %p", controlView, self);
+      NSDebugLog(@"NSButtonCell+Eau: Control view %p is not an NSButton or is nil for cell %p", controlView, self);
     }
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in safelyMakeButtonSelectedAndHighlighted for cell %p: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in safelyMakeButtonSelectedAndHighlighted for cell %p: %@", self, exception);
   }
 }
 
 // Clean up when the cell is deallocated
 - (void) dealloc
 {
-  EAULOG(@"NSButtonCell+Eau: dealloc called for button cell %p", self);
+  NSDebugLog(@"NSButtonCell+Eau: dealloc called for button cell %p", self);
   
   @try {
     // Cancel any pending operations
@@ -865,10 +865,10 @@ static NSMutableSet *returnImageCells = nil;
       [defaultButtonSetCells removeObject:cellPtr];
     }
     
-    EAULOG(@"NSButtonCell+Eau: Cleanup completed for button cell %p", self);
+    NSDebugLog(@"NSButtonCell+Eau: Cleanup completed for button cell %p", self);
   }
   @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in dealloc for cell %p: %@", self, exception);
+    NSDebugLog(@"NSButtonCell+Eau: ERROR in dealloc for cell %p: %@", self, exception);
   }
 }
 

--- a/NSCell+Eau.m
+++ b/NSCell+Eau.m
@@ -12,7 +12,7 @@
 
 @implementation Eau(NSCell)
 - (void) _overrideNSCellMethod_drawInteriorWithFrame: (NSRect)cellFrame inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSCellMethod_drawInteriorWithFrame:inView");
+  NSDebugLog(@"_overrideNSCellMethod_drawInteriorWithFrame:inView");
   NSCell *xself = (NSCell*) self;
   [xself EAUdrawInteriorWithFrame:cellFrame inView:controlView];
 }

--- a/NSFont+Eau.m
+++ b/NSFont+Eau.m
@@ -45,7 +45,7 @@ __attribute__((constructor))
 static void initFontSwizzling(void) {
   Class fontClass = [NSFont class];
   if (!fontClass) {
-    EAULOG(@"NSFont+Eau: ERROR - NSFont class not found");
+    NSDebugLog(@"NSFont+Eau: ERROR - NSFont class not found");
     return;
   }
 
@@ -66,10 +66,10 @@ static void initFontSwizzling(void) {
     }
   } else {
     if (!originalMenuBarFontMethod) {
-      EAULOG(@"NSFont+Eau: ERROR - Could not find original menuBarFontOfSize: method");
+      NSDebugLog(@"NSFont+Eau: ERROR - Could not find original menuBarFontOfSize: method");
     }
     if (!swizzledMenuBarFontMethod) {
-      EAULOG(@"NSFont+Eau: ERROR - Could not find eau_menuBarFontOfSize: method on NSFont");
+      NSDebugLog(@"NSFont+Eau: ERROR - Could not find eau_menuBarFontOfSize: method on NSFont");
     }
   }
 
@@ -90,10 +90,10 @@ static void initFontSwizzling(void) {
     }
   } else {
     if (!originalMenuFontMethod) {
-      EAULOG(@"NSFont+Eau: ERROR - Could not find original menuFontOfSize: method");
+      NSDebugLog(@"NSFont+Eau: ERROR - Could not find original menuFontOfSize: method");
     }
     if (!swizzledMenuFontMethod) {
-      EAULOG(@"NSFont+Eau: ERROR - Could not find eau_menuFontOfSize: method on NSFont");
+      NSDebugLog(@"NSFont+Eau: ERROR - Could not find eau_menuFontOfSize: method on NSFont");
     }
   }
 }

--- a/NSMenu+Eau.m
+++ b/NSMenu+Eau.m
@@ -101,7 +101,7 @@ static void _eau_swizzleMenuWindowFrameMethods(void)
   Class menuPanelClass = objc_getClass("NSMenuPanel");
   if (!menuPanelClass)
     {
-      EAULOG(@"Eau: NSMenuPanel class not found, skipping menu window swizzles");
+      NSDebugLog(@"Eau: NSMenuPanel class not found, skipping menu window swizzles");
       return;
     }
 
@@ -112,7 +112,7 @@ static void _eau_swizzleMenuWindowFrameMethods(void)
     {
       s_orig_menuWindowSetFrameOrigin = (void (*)(id, SEL, NSPoint))method_getImplementation(mOrigin);
       method_setImplementation(mOrigin, (IMP)s_eau_menuWindowSetFrameOrigin);
-      EAULOG(@"Eau: Swizzled NSMenuPanel setFrameOrigin: for bottom-screen clamping");
+      NSDebugLog(@"Eau: Swizzled NSMenuPanel setFrameOrigin: for bottom-screen clamping");
     }
 
   // Swizzle setFrame:display: (catches sizeToFit calls that bypass setFrameOrigin:)
@@ -122,7 +122,7 @@ static void _eau_swizzleMenuWindowFrameMethods(void)
     {
       s_orig_menuWindowSetFrameDisplay = (void (*)(id, SEL, NSRect, BOOL))method_getImplementation(mFrameDisplay);
       method_setImplementation(mFrameDisplay, (IMP)s_eau_menuWindowSetFrameDisplay);
-      EAULOG(@"Eau: Swizzled NSMenuPanel setFrame:display: for bottom-screen clamping");
+      NSDebugLog(@"Eau: Swizzled NSMenuPanel setFrame:display: for bottom-screen clamping");
     }
 }
 
@@ -392,13 +392,13 @@ static void swizzleNSMenuMethod(Class menuClass,
 
   if (!originalMethod)
     {
-      EAULOG(@"Eau: Cannot swizzle NSMenu -%s: original method not found", methodName);
+      NSDebugLog(@"Eau: Cannot swizzle NSMenu -%s: original method not found", methodName);
       return;
     }
 
   if (!swizzledMethod)
     {
-      EAULOG(@"Eau: Cannot swizzle NSMenu -%s: swizzled method not found", methodName);
+      NSDebugLog(@"Eau: Cannot swizzle NSMenu -%s: swizzled method not found", methodName);
       return;
     }
 
@@ -407,12 +407,12 @@ static void swizzleNSMenuMethod(Class menuClass,
   IMP swizzledIMP = method_getImplementation(swizzledMethod);
   if (originalIMP == swizzledIMP)
     {
-      EAULOG(@"Eau: NSMenu -%s already swizzled, skipping", methodName);
+      NSDebugLog(@"Eau: NSMenu -%s already swizzled, skipping", methodName);
       return;
     }
 
   method_exchangeImplementations(originalMethod, swizzledMethod);
-  EAULOG(@"Eau: Swizzled NSMenu -%s for Macintosh menu support", methodName);
+  NSDebugLog(@"Eau: Swizzled NSMenu -%s for Macintosh menu support", methodName);
 }
 
 /**
@@ -427,11 +427,11 @@ static void initNSMenuSwizzling(void)
   Class menuClass = objc_getClass("NSMenu");
   if (!menuClass)
     {
-      EAULOG(@"Eau: Failed to get NSMenu class for swizzling");
+      NSDebugLog(@"Eau: Failed to get NSMenu class for swizzling");
       return;
     }
 
-  EAULOG(@"Eau: Installing NSMenu swizzles for Macintosh interface style support");
+  NSDebugLog(@"Eau: Installing NSMenu swizzles for Macintosh interface style support");
 
   // Swizzle -menuChanged
   // Posts notification when menu changes reach the main menu

--- a/NSMenuItemCell+Eau.m
+++ b/NSMenuItemCell+Eau.m
@@ -14,20 +14,20 @@
 
 // Swizzled implementation for titleWidth - adds padding
 - (CGFloat)eau_titleWidth {
-  EAULOG(@"NSMenuItemCell+Eau: eau_titleWidth called");
+  NSDebugLog(@"NSMenuItemCell+Eau: eau_titleWidth called");
 
   // After swizzling, this message sends the original titleWidth implementation
   CGFloat originalWidth = [self eau_titleWidth];
   CGFloat paddedWidth = originalWidth + EAU_MENU_ITEM_PADDING;
 
-  EAULOG(@"NSMenuItemCell+Eau: eau_titleWidth originalWidth=%f paddedWidth=%f", originalWidth, paddedWidth);
+  NSDebugLog(@"NSMenuItemCell+Eau: eau_titleWidth originalWidth=%f paddedWidth=%f", originalWidth, paddedWidth);
 
   return paddedWidth;
 }
 
 // Swizzled implementation for titleRectForBounds: - shifts title to center in padded space
 - (NSRect)eau_titleRectForBounds:(NSRect)cellFrame {
-  EAULOG(@"NSMenuItemCell+Eau: eau_titleRectForBounds: called with cellFrame=(%f, %f, %f, %f)",
+  NSDebugLog(@"NSMenuItemCell+Eau: eau_titleRectForBounds: called with cellFrame=(%f, %f, %f, %f)",
         cellFrame.origin.x, cellFrame.origin.y, cellFrame.size.width, cellFrame.size.height);
 
   // After swizzling, this message sends the original titleRectForBounds: implementation
@@ -36,7 +36,7 @@
   // Shift by half padding to horizontally center in padded space
   originalRect.origin.x += (EAU_MENU_ITEM_PADDING / 2.0);
 
-  EAULOG(@"NSMenuItemCell+Eau: eau_titleRectForBounds: returning rect=(%f, %f, %f, %f)",
+  NSDebugLog(@"NSMenuItemCell+Eau: eau_titleRectForBounds: returning rect=(%f, %f, %f, %f)",
         originalRect.origin.x, originalRect.origin.y, originalRect.size.width, originalRect.size.height);
 
   return originalRect;
@@ -106,7 +106,7 @@ static void initMenuItemCellSwizzling(void) {
 
 // Override drawKeyEquivalentWithFrame to intercept just the key equivalent drawing
 - (void) _overrideNSMenuItemCellMethod_drawKeyEquivalentWithFrame: (NSRect)cellFrame inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSMenuItemCellMethod_drawKeyEquivalentWithFrame:inView:");
+  NSDebugLog(@"_overrideNSMenuItemCellMethod_drawKeyEquivalentWithFrame:inView:");
   NSMenuItemCell *xself = (NSMenuItemCell*)self;
   [xself EAUdrawKeyEquivalentWithFrame:cellFrame inView:controlView];
 }
@@ -153,10 +153,10 @@ static void initMenuItemCellSwizzling(void) {
       
       [arrow compositeToPoint: position operation: NSCompositeSourceOver];
       
-      EAULOG(@"NSMenuItemCell+Eau: Drew submenu arrow at position: {%.1f, %.1f} size: {%.1f, %.1f}",
+      NSDebugLog(@"NSMenuItemCell+Eau: Drew submenu arrow at position: {%.1f, %.1f} size: {%.1f, %.1f}",
              position.x, position.y, size.width, size.height);
     } else {
-      EAULOG(@"NSMenuItemCell+Eau: WARNING - No arrow image found for submenu item '%@'", [menuItem title]);
+      NSDebugLog(@"NSMenuItemCell+Eau: WARNING - No arrow image found for submenu item '%@'", [menuItem title]);
     }
     return; // Submenu items don't have key equivalents, so we're done
   }
@@ -166,7 +166,7 @@ static void initMenuItemCellSwizzling(void) {
     NSString *originalKeyEquivalent = [menuItem keyEquivalent];
     NSUInteger modifierMask = [menuItem keyEquivalentModifierMask];
     
-    EAULOG(@"NSMenuItemCell+Eau: Drawing key equivalent for '%@': '%@', modifiers: %lu", 
+    NSDebugLog(@"NSMenuItemCell+Eau: Drawing key equivalent for '%@': '%@', modifiers: %lu", 
            [menuItem title], originalKeyEquivalent, (unsigned long)modifierMask);
     
     // Convert the key equivalent to Mac style if needed
@@ -174,7 +174,7 @@ static void initMenuItemCellSwizzling(void) {
       NSString *macStyleKeyEquivalent = [self EAUconvertKeyEquivalentToMacStyle:originalKeyEquivalent withModifiers:modifierMask];
       
       if (![macStyleKeyEquivalent isEqualToString:originalKeyEquivalent]) {
-        EAULOG(@"NSMenuItemCell+Eau: Drawing Mac style key equivalent '%@' instead of '%@'", macStyleKeyEquivalent, originalKeyEquivalent);
+        NSDebugLog(@"NSMenuItemCell+Eau: Drawing Mac style key equivalent '%@' instead of '%@'", macStyleKeyEquivalent, originalKeyEquivalent);
         
         // Draw the Mac-style key equivalent manually
         NSFont *font = [NSFont menuFontOfSize:0];
@@ -203,7 +203,7 @@ static void initMenuItemCellSwizzling(void) {
         
         [macStyleKeyEquivalent drawInRect:textRect withAttributes:attributes];
         
-        EAULOG(@"NSMenuItemCell+Eau: Drew Mac style key equivalent at rect: {{%.1f, %.1f}, {%.1f, %.1f}}", 
+        NSDebugLog(@"NSMenuItemCell+Eau: Drew Mac style key equivalent at rect: {{%.1f, %.1f}, {%.1f, %.1f}}", 
                textRect.origin.x, textRect.origin.y, textRect.size.width, textRect.size.height);
         return;
       }
@@ -211,12 +211,12 @@ static void initMenuItemCellSwizzling(void) {
   }
   
   // If no conversion needed, do nothing - let the normal drawing process handle it
-  EAULOG(@"NSMenuItemCell+Eau: No conversion needed, skipping custom drawing");
+  NSDebugLog(@"NSMenuItemCell+Eau: No conversion needed, skipping custom drawing");
 }
 
 - (NSString*) EAUconvertKeyEquivalentToMacStyle: (NSString*)keyEquivalent withModifiers: (NSUInteger)modifierMask
 {
-  EAULOG(@"NSMenuItemCell+Eau: Converting key equivalent '%@' with modifiers %lu", keyEquivalent, (unsigned long)modifierMask);
+  NSDebugLog(@"NSMenuItemCell+Eau: Converting key equivalent '%@' with modifiers %lu", keyEquivalent, (unsigned long)modifierMask);
   
   if (!keyEquivalent || [keyEquivalent length] == 0) {
     return keyEquivalent;
@@ -227,7 +227,7 @@ static void initMenuItemCellSwizzling(void) {
     NSString *key = [keyEquivalent substringFromIndex:1];
     NSString *result = [NSString stringWithFormat:@"⌘%@", [key uppercaseString]];
     
-    EAULOG(@"NSMenuItemCell+Eau: Converted old format '%@' to Mac style: '%@'", keyEquivalent, result);
+    NSDebugLog(@"NSMenuItemCell+Eau: Converted old format '%@' to Mac style: '%@'", keyEquivalent, result);
     return result;
   }
   
@@ -282,11 +282,11 @@ static void initMenuItemCellSwizzling(void) {
     
     [result appendString:keyToAdd];
     
-    EAULOG(@"NSMenuItemCell+Eau: Converted to Mac style: '%@'", result);
+    NSDebugLog(@"NSMenuItemCell+Eau: Converted to Mac style: '%@'", result);
     return result;
   }
   
-  EAULOG(@"NSMenuItemCell+Eau: No conversion needed for '%@'", keyEquivalent);
+  NSDebugLog(@"NSMenuItemCell+Eau: No conversion needed for '%@'", keyEquivalent);
   return keyEquivalent;
 }
 

--- a/NSMenuView+Eau.m
+++ b/NSMenuView+Eau.m
@@ -10,7 +10,7 @@
 
 - (NSPoint)eau_locationForSubmenu:(NSMenu *)aSubmenu
 {
-  EAULOG(@"NSMenuView+Eau: eau_locationForSubmenu: called for submenu %@", aSubmenu);
+  NSDebugLog(@"NSMenuView+Eau: eau_locationForSubmenu: called for submenu %@", aSubmenu);
 
   NSMenuView *menuView = (NSMenuView *)self;
   NSWindow *window = [menuView window];
@@ -44,7 +44,7 @@
       // If the menu would extend past the bottom screen border, shift it up.
       if (yPos < 0)
         {
-          EAULOG(@"NSMenuView+Eau: Horizontal menu extends past bottom border (yPos=%.1f), shifting up", yPos);
+          NSDebugLog(@"NSMenuView+Eau: Horizontal menu extends past bottom border (yPos=%.1f), shifting up", yPos);
           yPos = 0;
         }
       // Clamp horizontally so the menu fits on screen.
@@ -64,7 +64,7 @@
               screenOrigin.x = screenFrame.origin.x;
             }
         }
-      EAULOG(@"NSMenuView+Eau: Horizontal pos for '%@': itemRect=%@ screenOrigin=%@ subH=%.1f → (%.1f, %.1f)",
+      NSDebugLog(@"NSMenuView+Eau: Horizontal pos for '%@': itemRect=%@ screenOrigin=%@ subH=%.1f → (%.1f, %.1f)",
             [aSubmenu title], NSStringFromRect(itemRect), NSStringFromPoint(screenOrigin),
             subH, screenOrigin.x, yPos);
       return NSMakePoint(screenOrigin.x, yPos);
@@ -107,7 +107,7 @@
   // If the menu would extend past the bottom screen border, shift it up.
   if (yPos < 0)
     {
-      EAULOG(@"NSMenuView+Eau: Vertical submenu extends past bottom border (yPos=%.1f), shifting up", yPos);
+      NSDebugLog(@"NSMenuView+Eau: Vertical submenu extends past bottom border (yPos=%.1f), shifting up", yPos);
       yPos = 0;
     }
   // If the menu would extend past the top screen border, shift it down.
@@ -136,7 +136,7 @@
         }
     }
 
-  EAULOG(@"NSMenuView+Eau: Vertical pos for '%@': parentFrame=%@ itemScreen=%@ itemH=%.1f subH=%.1f → (%.1f, %.1f)",
+  NSDebugLog(@"NSMenuView+Eau: Vertical pos for '%@': parentFrame=%@ itemScreen=%@ itemH=%.1f subH=%.1f → (%.1f, %.1f)",
         [aSubmenu title], NSStringFromRect(parentFrame), NSStringFromPoint(screenOrigin),
         itemH, subH, xPos, yPos);
   return NSMakePoint(xPos, yPos);
@@ -151,7 +151,7 @@ static void initMenuViewSwizzling(void) {
 
   Class menuViewClass = objc_getClass("NSMenuView");
   if (!menuViewClass) {
-    EAULOG(@"NSMenuView+Eau: ERROR - NSMenuView class not found");
+    NSDebugLog(@"NSMenuView+Eau: ERROR - NSMenuView class not found");
     return;
   }
 
@@ -163,12 +163,12 @@ static void initMenuViewSwizzling(void) {
   Method swizzledMethod = class_getInstanceMethod(menuViewClass, swizzledSelector);
 
   if (!originalMethod) {
-    EAULOG(@"NSMenuView+Eau: ERROR - Could not find original locationForSubmenu: method");
+    NSDebugLog(@"NSMenuView+Eau: ERROR - Could not find original locationForSubmenu: method");
     return;
   }
 
   if (!swizzledMethod) {
-    EAULOG(@"NSMenuView+Eau: ERROR - Could not find eau_locationForSubmenu: method on NSMenuView");
+    NSDebugLog(@"NSMenuView+Eau: ERROR - Could not find eau_locationForSubmenu: method on NSMenuView");
     return;
   }
 
@@ -176,7 +176,7 @@ static void initMenuViewSwizzling(void) {
   IMP originalIMP = method_getImplementation(originalMethod);
   IMP swizzledIMP = method_getImplementation(swizzledMethod);
   if (originalIMP == swizzledIMP) {
-    EAULOG(@"NSMenuView+Eau: Swizzling skipped - implementations already identical");
+    NSDebugLog(@"NSMenuView+Eau: Swizzling skipped - implementations already identical");
     return;
   }
 

--- a/NSPopUpButton+Eau.m
+++ b/NSPopUpButton+Eau.m
@@ -7,7 +7,7 @@
 
 @implementation Eau (NSPopUpButton)
 - (void) _overrideNSPopUpButtonMethod_mouseDown: (NSEvent*)theEvent {
-  EAULOG(@"_overrideNSPopUpButtonMethod_mouseDown:");
+  NSDebugLog(@"_overrideNSPopUpButtonMethod_mouseDown:");
   NSPopUpButton *xself = (NSPopUpButton*)self;
   [xself EAUmouseDown:theEvent];
 }

--- a/NSSearchFieldCell+Eau.m
+++ b/NSSearchFieldCell+Eau.m
@@ -25,51 +25,51 @@
 
 @implementation Eau(NSSearchFieldCell)
 - (void) _overrideNSSearchFieldCellMethod_drawWithFrame: (NSRect)cellFrame inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSSearchFieldCellMethod_drawWithFrame:inView");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod_drawWithFrame:inView");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   [xself EAUdrawWithFrame: (NSRect)cellFrame inView: (NSView*)controlView];
 }
 
 - (NSRect) _overrideNSSearchFieldCellMethod_searchTextRectForBounds: (NSRect)rect {
-  EAULOG(@"_overrideNSSearchFieldCellMethod_searchTextRectForBounds:");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod_searchTextRectForBounds:");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   return [xself EAUsearchTextRectForBounds:rect];
 }
 
 - (void) _overrideNSSearchFieldCellMethod__drawBorderAndBackgroundWithFrame: (NSRect)cellFrame
 								     inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSSearchFieldCellMethod__drawBorderAndBackgroundWithFrame:inView:");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod__drawBorderAndBackgroundWithFrame:inView:");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   [xself _EAUdrawBorderAndBackgroundWithFrame:cellFrame inView:controlView];
 }
 
 - (void) _overrideNSSearchFieldCellMethod_drawInteriorWithFrame: (NSRect)cellFrame inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSSearchFieldCellMethod_drawInteriorWithFrame:inView:");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod_drawInteriorWithFrame:inView:");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   [xself EAUdrawInteriorWithFrame:cellFrame inView:controlView];
 }
 
 - (void) _overrideNSSearchFieldCellMethod__drawEditorWithFrame: (NSRect)cellFrame
 							inView: (NSView *)controlView {
-  EAULOG(@"_overrideNSSearchFieldCellMethod__drawEditorWithFrame:inView:");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod__drawEditorWithFrame:inView:");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   [xself _EAUdrawEditorWithFrame:cellFrame inView:controlView];
 }
 
 - (NSRect) _overrideNSSearchFieldCellMethod_titleRectForBounds: (NSRect)theRect {
-  EAULOG(@"_overrideNSSearchFieldCellMethod_titleRectForBounds:");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod_titleRectForBounds:");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   return [xself EAUtitleRectForBounds:theRect];
 }
 
 - (NSRect) _overrideNSSearchFieldCellMethod_searchButtonRectForBounds: (NSRect)rect {
-  EAULOG(@"_overrideNSSearchFieldCellMethod_searchButtonRectForBounds:");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod_searchButtonRectForBounds:");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   return [xself EAUsearchButtonRectForBounds:rect];  
 }
 
 - (NSRect) _overrideNSSearchFieldCellMethod_cancelButtonRectForBounds: (NSRect)rect {
-  EAULOG(@"_overrideNSSearchFieldCellMethod_cancelButtonRectForBounds:");
+  NSDebugLog(@"_overrideNSSearchFieldCellMethod_cancelButtonRectForBounds:");
   NSSearchFieldCell *xself = (NSSearchFieldCell*)self;
   return [xself EAUcancelButtonRectForBounds:rect];
 }

--- a/NSSegmentedCell+Eau.m
+++ b/NSSegmentedCell+Eau.m
@@ -9,7 +9,7 @@
 // - (NSColor*) textColor
 - (NSColor*) _overrideNSSegmentedCellMethod_textColor
 {
-  EAULOG(@"_overrideNSSegmentedCellMethod_textColor");
+  NSDebugLog(@"_overrideNSSegmentedCellMethod_textColor");
   //IT DOES NOT WORKS
   NSSegmentedCell *xself = (NSSegmentedCell*) self;
   
@@ -25,7 +25,7 @@
 - (void) _overrideNSSegmentedCellMethod__drawBorderAndBackgroundWithFrame: (NSRect)cellFrame
                                     inView: (NSView*)controlView
 {
-  EAULOG(@"_overrideNSSegmentedCellMethod__drawBorderAndBackgroundWithFrame");
+  NSDebugLog(@"_overrideNSSegmentedCellMethod__drawBorderAndBackgroundWithFrame");
   NSSegmentedCell *xself = (NSSegmentedCell*) self;
   CGFloat radius = 4;
   cellFrame = NSInsetRect(cellFrame, 0.5, 0.5);
@@ -61,7 +61,7 @@
 // - (void) drawWithFrame: (NSRect)cellFrame inView: (NSView*)controlView
 - (void) _overrideNSSegmentedCellMethod_drawWithFrame: (NSRect)cellFrame inView: (NSView*)controlView
 {
-  EAULOG(@"_overrideNSSegmentedCellMethod_drawWithFrame");
+  NSDebugLog(@"_overrideNSSegmentedCellMethod_drawWithFrame");
   NSCell *xself = (NSCell*) self;
   if (NSIsEmptyRect(cellFrame))
     return;

--- a/NSTextFieldCell+Eau.m
+++ b/NSTextFieldCell+Eau.m
@@ -32,20 +32,20 @@
 
 @implementation Eau(NSTextFieldCell)
 - (void) _overrideNSTextFieldCellMethod_drawInteriorWithFrame: (NSRect)cellFrame inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSTextFieldCellMethod_drawInteriorWithFrame:inView:");
+  NSDebugLog(@"_overrideNSTextFieldCellMethod_drawInteriorWithFrame:inView:");
   NSTextFieldCell *xself = (NSTextFieldCell*)self;
   [xself EAUdrawInteriorWithFrame:cellFrame inView:controlView];
 }
 
 - (void) _overrideNSTextFieldCellMethod_drawWithFrame: (NSRect)cellFrame inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSTextFieldCellMethod_drawWithFrame:inView:");
+  NSDebugLog(@"_overrideNSTextFieldCellMethod_drawWithFrame:inView:");
   NSTextFieldCell *xself = (NSTextFieldCell*)self;
   [xself EAUdrawWithFrame:cellFrame inView:controlView];
 }
 
 - (void) _overrideNSTextFieldCellMethod__drawEditorWithFrame: (NSRect)cellFrame
                                                      inView: (NSView*)controlView {
-  EAULOG(@"_overrideNSTextFieldCellMethod__drawEditorWithFrame:inView:");
+  NSDebugLog(@"_overrideNSTextFieldCellMethod__drawEditorWithFrame:inView:");
   NSTextFieldCell *xself = (NSTextFieldCell*)self;
   [xself _EAUdrawEditorWithFrame:cellFrame inView:controlView];
 }
@@ -56,7 +56,7 @@
                 delegate: (id)anObject
                    start: (NSInteger)selStart
 		  length: (NSInteger)selLength {
-  EAULOG(@"_overrrideNSTextFieldCellMethod_selectWithFrame::::::");
+  NSDebugLog(@"_overrrideNSTextFieldCellMethod_selectWithFrame::::::");
   NSTextFieldCell *xself = (NSTextFieldCell*)self;
   [xself selectWithFrame:aRect
 		  inView:controlView
@@ -70,7 +70,7 @@
                 editor: (NSText*)textObject
               delegate: (id)anObject
 		event: (NSEvent*)theEvent {
-  EAULOG(@"_overrideNSTextFieldCellMethod_editWithFrame:");
+  NSDebugLog(@"_overrideNSTextFieldCellMethod_editWithFrame:");
   NSTextFieldCell *xself = (NSTextFieldCell*)self;
   [xself editWithFrame:aRect
 		inView:controlView
@@ -95,7 +95,7 @@
     }
   else
     {
-      EAULOG(@"EAUdrawWithFrame: Drawing in normal mode - standard behavior");
+      NSDebugLog(@"EAUdrawWithFrame: Drawing in normal mode - standard behavior");
     }
 }
 
@@ -113,7 +113,7 @@
   }
   else
     {
-      EAULOG(@"EAUdrawInteriorWithFrame: Drawing in normal mode");
+      NSDebugLog(@"EAUdrawInteriorWithFrame: Drawing in normal mode");
 	// cellFrame.origin.y-= 1;
 	// cellFrame.size.height += 2;
 

--- a/NSWindow+Eau.m
+++ b/NSWindow+Eau.m
@@ -101,7 +101,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
 {
   if (window == nil)
     {
-      EAULOG(@"EauWindowLog: %@ window=(null)", event);
+      NSDebugLog(@"EauWindowLog: %@ window=(null)", event);
       return;
     }
   NSString *summary = nil;
@@ -109,7 +109,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
     {
       summary = EAUDialogTextSummary(window);
     }
-  EAULOG(@"EauWindowLog: %@ window=%p class=%@ title='%@' visible=%d key=%d main=%d level=%ld",
+  NSDebugLog(@"EauWindowLog: %@ window=%p class=%@ title='%@' visible=%d key=%d main=%d level=%ld",
          event,
          window,
          NSStringFromClass([window class]),
@@ -120,7 +120,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
          (long)[window level]);
   if (summary != nil && [summary length] > 0)
     {
-      EAULOG(@"EauDialog: window=%p class=%@ text='%@'", window, NSStringFromClass([window class]), summary);
+      NSDebugLog(@"EauDialog: window=%p class=%@ text='%@'", window, NSStringFromClass([window class]), summary);
     }
 }
 
@@ -246,7 +246,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
               }
             } else {
               // Button is disabled, stop the animation and reset pulse progress
-              EAULOG(@"DefaultButtonAnimation: Button cell is disabled, stopping animation");
+              NSDebugLog(@"DefaultButtonAnimation: Button cell is disabled, stopping animation");
               defaultbuttoncell.pulseProgress = [NSNumber numberWithFloat: 0.0];
               NSView *cv = [defaultbuttoncell controlView];
               if (cv) {
@@ -263,7 +263,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
   if (defaultbuttoncell && progress >= 1.0)
   {
     reverse = !reverse;
-    EAULOG(@"DefaultButtonAnimation: Reversing direction and restarting animation");
+    NSDebugLog(@"DefaultButtonAnimation: Reversing direction and restarting animation");
     if ([self isAnimating]) {
         [self startAnimation];
     }
@@ -287,9 +287,9 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
 @synthesize animation;
 - (id) initWithButtonCell: (NSButtonCell*) cell
 {
-  EAULOG(@"DefaultButtonAnimationController: initWithButtonCell called with cell %p", cell);
+  NSDebugLog(@"DefaultButtonAnimationController: initWithButtonCell called with cell %p", cell);
   if (self = [super init]) {
-    self.buttoncell = cell;    EAULOG(@"DefaultButtonAnimationController: Initialized for button cell %p", cell);    
+    self.buttoncell = cell;    NSDebugLog(@"DefaultButtonAnimationController: Initialized for button cell %p", cell);    
     // Register for additional window notifications to handle visibility changes
     [[NSNotificationCenter defaultCenter] addObserver:self 
                                              selector:@selector(windowWillClose:) 
@@ -328,14 +328,14 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
                   forKeyPath:@"enabled"
                      options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
                      context:NULL];
-        EAULOG(@"DefaultButtonAnimationController: Added KVO observer for enabled property on control %p", control);
+        NSDebugLog(@"DefaultButtonAnimationController: Added KVO observer for enabled property on control %p", control);
       }
       @catch (NSException *exception) {
-        EAULOG(@"DefaultButtonAnimationController: ERROR adding KVO observer for enabled property: %@", exception);
+        NSDebugLog(@"DefaultButtonAnimationController: ERROR adding KVO observer for enabled property: %@", exception);
       }
     }
     
-    EAULOG(@"DefaultButtonAnimationController: Successfully initialized with cell %p", cell);
+    NSDebugLog(@"DefaultButtonAnimationController: Successfully initialized with cell %p", cell);
   }
   return self;
 }
@@ -360,14 +360,14 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
  */
 - (id)windowWillReturnFieldEditor:(id)fieldEditor toObject:(id)anObject
 {
-  EAULOG(@"DefaultButtonAnimationController: windowWillReturnFieldEditor called for object %p, returning nil (use default)", anObject);
+  NSDebugLog(@"DefaultButtonAnimationController: windowWillReturnFieldEditor called for object %p, returning nil (use default)", anObject);
   return nil;  // Return nil to use the default field editor
 }
 
 
 - (void) dealloc
 {
-  EAULOG(@"DefaultButtonAnimationController: dealloc called");
+  NSDebugLog(@"DefaultButtonAnimationController: dealloc called");
   
   @try {
     // Stop animation and remove all notifications
@@ -391,10 +391,10 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
           NSControl *control = (NSControl *)cv;
           // paracoid check: only remove if it's still alive enough to have property
           [control removeObserver:self forKeyPath:@"enabled"];
-          EAULOG(@"DefaultButtonAnimationController: Removed KVO observer for enabled property on control %p", control);
+          NSDebugLog(@"DefaultButtonAnimationController: Removed KVO observer for enabled property on control %p", control);
         }
       } @catch (NSException *exception) {
-        EAULOG(@"DefaultButtonAnimationController: Exception removing KVO: %@", exception);
+        NSDebugLog(@"DefaultButtonAnimationController: Exception removing KVO: %@", exception);
       }
       
       @try {
@@ -403,7 +403,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
       } @catch (id ex) {}
     }
   } @catch (NSException *exception) {
-    EAULOG(@"DefaultButtonAnimationController: ERROR in dealloc: %@", exception);
+    NSDebugLog(@"DefaultButtonAnimationController: ERROR in dealloc: %@", exception);
   }
   
   buttoncell = nil;
@@ -411,12 +411,12 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
 
 - (void) startPulse
 {
-  EAULOG(@"DefaultButtonAnimationController: startPulse called for cell %p", buttoncell);
+  NSDebugLog(@"DefaultButtonAnimationController: startPulse called for cell %p", buttoncell);
   [self startPulse: NO];
 }
 - (void) startPulse: (BOOL) reverse
 {
-  EAULOG(@"DefaultButtonAnimationController: startPulse:reverse called with reverse=%d for cell %p", reverse, buttoncell);
+  NSDebugLog(@"DefaultButtonAnimationController: startPulse:reverse called with reverse=%d for cell %p", reverse, buttoncell);
   
   // Check if the button cell is enabled before starting animation
   BOOL isEnabled = YES;
@@ -425,7 +425,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
   }
   
   if (!isEnabled) {
-    EAULOG(@"DefaultButtonAnimationController: Button cell is disabled, not starting animation");
+    NSDebugLog(@"DefaultButtonAnimationController: Button cell is disabled, not starting animation");
     return;
   }
   
@@ -438,9 +438,9 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
   [animation setAnimationBlockingMode:NSAnimationNonblocking];
   animation.defaultbuttoncell = buttoncell;
   
-  EAULOG(@"DefaultButtonAnimationController: Starting animation %p for cell %p", animation, buttoncell);
+  NSDebugLog(@"DefaultButtonAnimationController: Starting animation %p for cell %p", animation, buttoncell);
   [animation startAnimation];
-  EAULOG(@"DefaultButtonAnimationController: Animation started for cell %p", buttoncell);
+  NSDebugLog(@"DefaultButtonAnimationController: Animation started for cell %p", buttoncell);
 }
 - (void)animation:(NSAnimation *)a
             didReachProgressMark:(NSAnimationProgress)progress
@@ -451,7 +451,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
 
 - (void)windowDidResignKey:(NSNotification *)notification
 {
-      EAULOG(@"DefaultButtonAnimationController: Window resigned key, stopping animation");
+      NSDebugLog(@"DefaultButtonAnimationController: Window resigned key, stopping animation");
       [animation stopAnimation];
 }
 
@@ -461,21 +461,21 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
       NSWindow *window = [notification object];
       NSWindow *buttonWindow = [[buttoncell controlView] window];
       
-      EAULOG(@"DefaultButtonAnimationController: Window became key notification received");
-      EAULOG(@"DefaultButtonAnimationController: Notifying window %p, button window %p", window, buttonWindow);
+      NSDebugLog(@"DefaultButtonAnimationController: Window became key notification received");
+      NSDebugLog(@"DefaultButtonAnimationController: Notifying window %p, button window %p", window, buttonWindow);
       
       if (window == buttonWindow)
         {
           if ([self shouldAnimationBeRunning]) {
-              EAULOG(@"DefaultButtonAnimationController: Button's window became key and button is enabled, starting animation");
+              NSDebugLog(@"DefaultButtonAnimationController: Button's window became key and button is enabled, starting animation");
               [animation startAnimation];
           } else {
-              EAULOG(@"DefaultButtonAnimationController: Button's window became key but button is disabled, not starting animation");
+              NSDebugLog(@"DefaultButtonAnimationController: Button's window became key but button is disabled, not starting animation");
           }
         }
       else
         {
-          EAULOG(@"DefaultButtonAnimationController: Different window became key, ignoring");
+          NSDebugLog(@"DefaultButtonAnimationController: Different window became key, ignoring");
         }
 }
 
@@ -490,7 +490,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
     } @catch (id ex) {}
     
     if (closingWindow == buttonWindow || closingWindow == nil) {
-        EAULOG(@"DefaultButtonAnimationController: Button's window is closing, stopping animation");
+        NSDebugLog(@"DefaultButtonAnimationController: Button's window is closing, stopping animation");
         if (animation) {
             [animation stopAnimation];
         }
@@ -503,7 +503,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
     NSWindow *buttonWindow = [[buttoncell controlView] window];
     
     if (miniaturizedWindow == buttonWindow) {
-        EAULOG(@"DefaultButtonAnimationController: Button's window was miniaturized, stopping animation");
+        NSDebugLog(@"DefaultButtonAnimationController: Button's window was miniaturized, stopping animation");
         [animation stopAnimation];
     }
 }
@@ -514,24 +514,24 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
     NSWindow *buttonWindow = [[buttoncell controlView] window];
     
     if (deminiaturizedWindow == buttonWindow && [self shouldAnimationBeRunning]) {
-        EAULOG(@"DefaultButtonAnimationController: Button's window was deminiaturized and button is enabled, starting animation");
+        NSDebugLog(@"DefaultButtonAnimationController: Button's window was deminiaturized and button is enabled, starting animation");
         [animation startAnimation];
     }
 }
 
 - (void)applicationDidHide:(NSNotification *)notification
 {
-    EAULOG(@"DefaultButtonAnimationController: Application was hidden, stopping animation");
+    NSDebugLog(@"DefaultButtonAnimationController: Application was hidden, stopping animation");
     [animation stopAnimation];
 }
 
 - (void)applicationDidUnhide:(NSNotification *)notification
 {
     if ([self shouldAnimationBeRunning]) {
-        EAULOG(@"DefaultButtonAnimationController: Application was unhidden and button is enabled and visible, starting animation");
+        NSDebugLog(@"DefaultButtonAnimationController: Application was unhidden and button is enabled and visible, starting animation");
         [animation startAnimation];
     } else {
-        EAULOG(@"DefaultButtonAnimationController: Application was unhidden but button is disabled or window not visible, not starting animation");
+        NSDebugLog(@"DefaultButtonAnimationController: Application was unhidden but button is disabled or window not visible, not starting animation");
     }
 }
 
@@ -569,23 +569,23 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
                        context:(void *)context
 {
     if ([keyPath isEqualToString:@"enabled"]) {
-        EAULOG(@"DefaultButtonAnimationController: Button enabled state changed, checking animation state");
+        NSDebugLog(@"DefaultButtonAnimationController: Button enabled state changed, checking animation state");
         
         // Immediately reset pulse progress if button becomes disabled
         if ([buttoncell respondsToSelector:@selector(isEnabled)] && ![buttoncell isEnabled]) {
-            EAULOG(@"DefaultButtonAnimationController: Button disabled - immediately resetting pulse progress");
+            NSDebugLog(@"DefaultButtonAnimationController: Button disabled - immediately resetting pulse progress");
             buttoncell.pulseProgress = [NSNumber numberWithFloat: 0.0];
             [[buttoncell controlView] setNeedsDisplay: YES];
         }
         
         if ([self shouldAnimationBeRunning]) {
             if (![animation isAnimating]) {
-                EAULOG(@"DefaultButtonAnimationController: Button became enabled and visible, starting animation");
+                NSDebugLog(@"DefaultButtonAnimationController: Button became enabled and visible, starting animation");
                 [self startPulse];
             }
         } else {
             if ([animation isAnimating]) {
-                EAULOG(@"DefaultButtonAnimationController: Button became disabled or invisible, stopping animation");
+                NSDebugLog(@"DefaultButtonAnimationController: Button became disabled or invisible, stopping animation");
                 [animation stopAnimation];
             }
         }
@@ -606,7 +606,7 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
 - (NSButton *) standardWindowButton: (NSWindowButton)button
                        forStyleMask: (NSUInteger) mask
 {
-  EAULOG(@"NSWindow+Eau standardWindowButton:forStyleMask:");
+  NSDebugLog(@"NSWindow+Eau standardWindowButton:forStyleMask:");
 
   if (EauTitleBarButtonStyleIsOrb()) {
     EauWindowButton *orbButton = [[EauWindowButton alloc] init];
@@ -694,14 +694,14 @@ static void EAUWindowLog(NSString *event, NSWindow *window)
 }
 
 - (void) _overrideNSWindowMethod_setDefaultButtonCell: (NSButtonCell *)aCell {
-  EAULOG(@"_overrideNSWindowMethod_setDefaultButtonCell:");
+  NSDebugLog(@"_overrideNSWindowMethod_setDefaultButtonCell:");
   NSWindow *xself = (NSWindow*)self;
   [xself EAUsetDefaultButtonCell:aCell];
 }
 
 // Override the center method to position windows using golden ratio
 - (void) _overrideNSWindowMethod_center {
-  EAULOG(@"_overrideNSWindowMethod_center: Positioning window with golden ratio");
+  NSDebugLog(@"_overrideNSWindowMethod_center: Positioning window with golden ratio");
   NSWindow *xself = (NSWindow*)self;
   [xself EAUcenter];
 }
@@ -750,7 +750,7 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
  */
 - (void) EAUsetDefaultButtonCell: (NSButtonCell *)aCell
 {
-  EAULOG(@"NSWindow+Eau: EAUsetDefaultButtonCell called with cell %p for window %p", aCell, self);
+  NSDebugLog(@"NSWindow+Eau: EAUsetDefaultButtonCell called with cell %p for window %p", aCell, self);
   
   _defaultButtonCell = aCell;
   
@@ -773,7 +773,7 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
   [aCell setKeyEquivalentModifierMask: 0];
   [aCell setIsDefaultButton: [NSNumber numberWithBool: YES]];
 
-  EAULOG(@"NSWindow+Eau: Creating DefaultButtonAnimationController for cell %p", aCell);
+  NSDebugLog(@"NSWindow+Eau: Creating DefaultButtonAnimationController for cell %p", aCell);
   DefaultButtonAnimationController * animationcontroller = [[DefaultButtonAnimationController alloc] initWithButtonCell: aCell];
 
   // Retain controller via association to ensure it stays alive
@@ -803,7 +803,7 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
    */
   if ([self isKindOfClass: NSClassFromString(@"GWDialog")])
     {
-      EAULOG(@"NSWindow+Eau: Skipping delegate assignment for GWDialog %p to preserve text field focus", self);
+      NSDebugLog(@"NSWindow+Eau: Skipping delegate assignment for GWDialog %p to preserve text field focus", self);
     }
   else
     {
@@ -811,19 +811,19 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
       id currentDelegate = [self delegate];
       if (currentDelegate == nil || currentDelegate == animationcontroller)
         {
-          EAULOG(@"NSWindow+Eau: Setting window delegate to animation controller %p for window %p", animationcontroller, self);
+          NSDebugLog(@"NSWindow+Eau: Setting window delegate to animation controller %p for window %p", animationcontroller, self);
           [self setDelegate: animationcontroller];
         }
       else
         {
-          EAULOG(@"NSWindow+Eau: Preserving existing delegate %@ for window %p", currentDelegate, self);
+          NSDebugLog(@"NSWindow+Eau: Preserving existing delegate %@ for window %p", currentDelegate, self);
         }
     }
   
-  EAULOG(@"NSWindow+Eau: Starting pulse animation for cell %p", aCell);
+  NSDebugLog(@"NSWindow+Eau: Starting pulse animation for cell %p", aCell);
   [animationcontroller startPulse];
   
-  EAULOG(@"NSWindow+Eau: Default button cell setup completed for cell %p", aCell);
+  NSDebugLog(@"NSWindow+Eau: Default button cell setup completed for cell %p", aCell);
 }
 
 - (void) animateDefaultButton: (id)sender
@@ -833,7 +833,7 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
 // Golden ratio positioning method
 - (void) EAUcenter
 {
-  EAULOG(@"NSWindow+Eau: EAUcenter called - applying golden ratio positioning");
+  NSDebugLog(@"NSWindow+Eau: EAUcenter called - applying golden ratio positioning");
   
   NSScreen *screen = [self screen];
   if (!screen) {
@@ -841,7 +841,7 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
   }
   
   if (!screen) {
-    EAULOG(@"NSWindow+Eau: No screen available, using standard center");
+    NSDebugLog(@"NSWindow+Eau: No screen available, using standard center");
     [self center];
     return;
   }
@@ -849,8 +849,8 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
   NSRect screenFrame = [screen visibleFrame];
   NSRect windowFrame = [self frame];
   
-  EAULOG(@"NSWindow+Eau: Screen frame: %@", NSStringFromRect(screenFrame));
-  EAULOG(@"NSWindow+Eau: Window frame: %@", NSStringFromRect(windowFrame));
+  NSDebugLog(@"NSWindow+Eau: Screen frame: %@", NSStringFromRect(screenFrame));
+  NSDebugLog(@"NSWindow+Eau: Window frame: %@", NSStringFromRect(windowFrame));
   
   // Golden ratio ≈ 1.618, inverse ≈ 0.618
   // Position the window vertically at the golden ratio point
@@ -881,7 +881,7 @@ static const void *kEAUDefaultButtonControllerKey = &kEAUDefaultButtonController
   
   NSRect newFrame = NSMakeRect(x, y, windowFrame.size.width, windowFrame.size.height);
   
-  EAULOG(@"NSWindow+Eau: New window frame with golden ratio: %@", NSStringFromRect(newFrame));
+  NSDebugLog(@"NSWindow+Eau: New window frame with golden ratio: %@", NSStringFromRect(newFrame));
   
   [self setFrame:newFrame display:YES];
 }


### PR DESCRIPTION
### What
Route all of the theme's `Eau:`-prefixed debug traces — the alert panel and the Menu.app bridging — through GNUstep's standard `NSDebugLog`, and remove the theme-local `EAULOG` macro entirely.

Previously these traces used unconditional `NSLog` (in `NSAlert+Eau.m` and `Eau.m`) or the bespoke `EAULOG` macro (a `#if 0` compile-time switch in `Eau.h`) elsewhere. This change converts every call site to `NSDebugLog` and deletes the macro. The two genuine error fallbacks are left as real `NSLog`. One `sendAction` result that is now consumed only by a gated log stays marked `__attribute__((unused))` so NDEBUG builds remain warning-free.

### Why
`NSDebugLog` is GNUstep's idiomatic debug-logging facility: it is gated at runtime by the `GNU-Debug` user default (level `dflt`) and stripped entirely under NDEBUG. That gives us the same silence-in-production behaviour the unconditional `NSLog` calls lacked, keeps the traces debuggable through the conventional GNUstep mechanism, and drops a custom macro in favour of the platform idiom.

No behavioural change in production: with the debug level unset the log arguments are never evaluated, exactly as before.

Note: the traces inside the embedded UIBridge service are intentionally left untouched here; they are removed wholesale by the separate change that deletes that service, so this change stays independent of it.

Fixes #41
