### PR TITLE
Fix NSSearchField infinite-recursion crash (SIGSEGV) on first draw

### DIFF
--- a/NSSearchFieldCell+Eau.m
+++ b/NSSearchFieldCell+Eau.m
@@ -80,14 +80,21 @@
 
 - (void) EAUdrawWithFrame: (NSRect)cellFrame inView: (NSView*)controlView
 {
-  // TS: unused
-  // NSRect frame = cellFrame;
-  [super drawWithFrame: [self searchTextRectForBounds: cellFrame ]
-	 inView: controlView];
- [_search_button_cell drawWithFrame: [self searchButtonRectForBounds: cellFrame] inView: controlView];
+  // Draw the Eau search bezel + the text interior directly. We must NOT call
+  // [super drawWithFrame:] here: Eau's theme-override mechanism re-dispatches
+  // drawWithFrame: dynamically back into THIS method (super does not escape the
+  // override), so the original code recursed until the stack overflowed and the
+  // app crashed (SIGSEGV) on first draw of any NSSearchField.
+  // Calling the EAU* helpers directly reproduces what NSCell's drawWithFrame:
+  // would have done (border/background + interior) without re-dispatching.
+  [self _EAUdrawBorderAndBackgroundWithFrame: cellFrame inView: controlView];
+  [self EAUdrawInteriorWithFrame: cellFrame inView: controlView];
+
+  [_search_button_cell drawWithFrame: [self searchButtonRectForBounds: cellFrame]
+			      inView: controlView];
   if ([[self stringValue] length] > 0)
     [_cancel_button_cell drawWithFrame: [self cancelButtonRectForBounds: cellFrame]
-		       inView: controlView];
+			        inView: controlView];
 }
 
 /* This method put the "x" cell inside the Text cell */


### PR DESCRIPTION
### What
Draw the search-field bezel and interior directly (border/background + interior helpers) instead of calling `[super drawWithFrame:]`.

### Why
The theme installs its `drawWithFrame:` override such that `super` re-dispatches back into the same override (it does not escape it), so the original code recursed until the stack overflowed and **any `NSSearchField` crashed (SIGSEGV) on first draw**. Calling the interior/background helpers directly reproduces what the base cell would draw without re-entering the override, so the field renders instead of crashing.

Fixes #42
