### PR TITLE
Remove no-op exception-masking @try/@catch in NSButtonCell+Eau.m

### DIFF
--- a/NSButtonCell+Eau.m
+++ b/NSButtonCell+Eau.m
@@ -132,15 +132,10 @@ static NSMutableSet *returnImageCells = nil;
 
   // Swizzle -drawInteriorWithFrame:inView: so we can ignore return images for
   // layout calculations (prevents title shifting when mouse is pressed).
-  @try {
-    Class cls = [NSButtonCell class];
-    Method orig = class_getInstanceMethod(cls, @selector(drawInteriorWithFrame:inView:));
-    Method swiz = class_getInstanceMethod(cls, @selector(EAU_drawInteriorWithFrame:inView:));
-    if (orig && swiz) method_exchangeImplementations(orig, swiz);
-  }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR swizzling drawInteriorWithFrame: %@", exception);
-  }
+  Class cls = [NSButtonCell class];
+  Method orig = class_getInstanceMethod(cls, @selector(drawInteriorWithFrame:inView:));
+  Method swiz = class_getInstanceMethod(cls, @selector(EAU_drawInteriorWithFrame:inView:));
+  if (orig && swiz) method_exchangeImplementations(orig, swiz);
 }
 
 // Helper methods to track processing state
@@ -301,30 +296,25 @@ static NSMutableSet *returnImageCells = nil;
 {
   EAULOG(@"NSButtonCell+Eau: enablePulsing called for button cell %p", self);
   
-  @try {
-    // Prevent multiple enablePulsing calls for the same cell
-    @synchronized(defaultButtonSetCells) {
-      NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
-      if ([defaultButtonSetCells containsObject:cellPtr]) {
-        EAULOG(@"NSButtonCell+Eau: Button cell %p already enabled for pulsing, skipping", self);
-        return;
-      }
+  // Prevent multiple enablePulsing calls for the same cell
+  @synchronized(defaultButtonSetCells) {
+    NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
+    if ([defaultButtonSetCells containsObject:cellPtr]) {
+      EAULOG(@"NSButtonCell+Eau: Button cell %p already enabled for pulsing, skipping", self);
+      return;
     }
-    
-    EAULOG(@"NSButtonCell+Eau: Setting button cell %p as default button", self);
-    [self setIsDefaultButton:@YES];
-    
-    EAULOG(@"NSButtonCell+Eau: Making button cell %p selected and highlighted", self);
-    [self safelyMakeButtonSelectedAndHighlighted];
-    
-    EAULOG(@"NSButtonCell+Eau: Starting strategy to set default button for cell %p", self);
-    [self trySetAsDefaultButtonWithStrategy];
-    
-    EAULOG(@"NSButtonCell+Eau: enablePulsing completed successfully for button cell %p", self);
   }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in enablePulsing for button cell %p: %@", self, exception);
-  }
+  
+  EAULOG(@"NSButtonCell+Eau: Setting button cell %p as default button", self);
+  [self setIsDefaultButton:@YES];
+  
+  EAULOG(@"NSButtonCell+Eau: Making button cell %p selected and highlighted", self);
+  [self safelyMakeButtonSelectedAndHighlighted];
+  
+  EAULOG(@"NSButtonCell+Eau: Starting strategy to set default button for cell %p", self);
+  [self trySetAsDefaultButtonWithStrategy];
+  
+  EAULOG(@"NSButtonCell+Eau: enablePulsing completed successfully for button cell %p", self);
 }
 
 // Try multiple strategies to find the window and set default button
@@ -332,80 +322,70 @@ static NSMutableSet *returnImageCells = nil;
 {
   EAULOG(@"NSButtonCell+Eau: trySetAsDefaultButtonWithStrategy called for button cell %p", self);
   
+  // Prevent multiple attempts for the same cell
+  @synchronized(defaultButtonSetCells) {
+    NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
+    if ([defaultButtonSetCells containsObject:cellPtr]) {
+      EAULOG(@"NSButtonCell+Eau: Button cell %p already processed, skipping", self);
+      return;
+    }
+  }
+  
+  // Try immediate window access
+  EAULOG(@"NSButtonCell+Eau: Trying direct window access for button cell %p", self);
+  if ([self tryDirectWindowAccess]) {
+    EAULOG(@"NSButtonCell+Eau: Direct window access succeeded for button cell %p", self);
+    return;
+  }
+  
+  // Search all windows for this button cell
+  EAULOG(@"NSButtonCell+Eau: Trying to search all windows for button cell %p", self);
+  if ([self trySearchAllWindows]) {
+    EAULOG(@"NSButtonCell+Eau: Window search succeeded for button cell %p", self);
+    return;
+  }
+  
+  // Defensive: Check if this is a modal panel or modal window - if so, don't schedule delayed attempt
+  // Modal windows are often short-lived and may be deallocated before timer fires
+  NSView *controlView = nil;
+  if ([self respondsToSelector:@selector(controlView)]) {
+    controlView = [self controlView];
+  }
+  if (!controlView || ![controlView isKindOfClass:[NSView class]]) {
+    EAULOG(@"NSButtonCell+Eau: Control view missing or invalid, skipping delayed attempt for cell %p", self);
+    return;
+  }
+
+  NSWindow *window = nil;
   @try {
-    // Prevent multiple attempts for the same cell
-    @synchronized(defaultButtonSetCells) {
-      NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
-      if ([defaultButtonSetCells containsObject:cellPtr]) {
-        EAULOG(@"NSButtonCell+Eau: Button cell %p already processed, skipping", self);
-        return;
-      }
-    }
-    
-    // Try immediate window access
-    EAULOG(@"NSButtonCell+Eau: Trying direct window access for button cell %p", self);
-    if ([self tryDirectWindowAccess]) {
-      EAULOG(@"NSButtonCell+Eau: Direct window access succeeded for button cell %p", self);
-      return;
-    }
-    
-    // Search all windows for this button cell
-    EAULOG(@"NSButtonCell+Eau: Trying to search all windows for button cell %p", self);
-    if ([self trySearchAllWindows]) {
-      EAULOG(@"NSButtonCell+Eau: Window search succeeded for button cell %p", self);
-      return;
-    }
-    
-    // Defensive: Check if this is a modal panel or modal window - if so, don't schedule delayed attempt
-    // Modal windows are often short-lived and may be deallocated before timer fires
-    NSView *controlView = nil;
-    if ([self respondsToSelector:@selector(controlView)]) {
-      controlView = [self controlView];
-    }
-    if (!controlView || ![controlView isKindOfClass:[NSView class]]) {
-      EAULOG(@"NSButtonCell+Eau: Control view missing or invalid, skipping delayed attempt for cell %p", self);
-      return;
-    }
-
-    NSWindow *window = nil;
-    @try {
-      window = [controlView window];
-    } @catch (NSException *windowException) {
-      EAULOG(@"NSButtonCell+Eau: Exception getting window for cell %p: %@", self, windowException);
-      return;
-    }
-
-    if (!window || ![window isKindOfClass:[NSWindow class]]) {
-      EAULOG(@"NSButtonCell+Eau: Window missing or invalid, skipping delayed attempt for cell %p", self);
-      return;
-    }
-
-    // Skip delayed attempts for panels (short-lived)
-    if ([window isKindOfClass:[NSPanel class]]) {
-      EAULOG(@"NSButtonCell+Eau: Button is in a panel, skipping delayed attempt for cell %p", self);
-      return;
-    }
-
-    // Skip delayed attempts for modal windows (short-lived, closed when modal session ends)
-    if ([NSApp modalWindow] == window) {
-      EAULOG(@"NSButtonCell+Eau: Button is in modal window, skipping delayed attempt for cell %p", self);
-      return;
-    }
-    
-    // Only schedule ONE delayed attempt to prevent loops
-    EAULOG(@"NSButtonCell+Eau: Scheduling single delayed attempt for button cell %p", self);
-    @try {
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [self finalAttemptSetAsDefaultButton];
-      });
-    }
-    @catch (NSException *performException) {
-      EAULOG(@"NSButtonCell+Eau: ERROR scheduling delayed attempt for cell %p: %@", self, performException);
-    }
+    window = [controlView window];
+  } @catch (NSException *windowException) {
+    EAULOG(@"NSButtonCell+Eau: Exception getting window for cell %p: %@", self, windowException);
+    return;
   }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in trySetAsDefaultButtonWithStrategy for cell %p: %@", self, exception);
+
+  if (!window || ![window isKindOfClass:[NSWindow class]]) {
+    EAULOG(@"NSButtonCell+Eau: Window missing or invalid, skipping delayed attempt for cell %p", self);
+    return;
   }
+
+  // Skip delayed attempts for panels (short-lived)
+  if ([window isKindOfClass:[NSPanel class]]) {
+    EAULOG(@"NSButtonCell+Eau: Button is in a panel, skipping delayed attempt for cell %p", self);
+    return;
+  }
+
+  // Skip delayed attempts for modal windows (short-lived, closed when modal session ends)
+  if ([NSApp modalWindow] == window) {
+    EAULOG(@"NSButtonCell+Eau: Button is in modal window, skipping delayed attempt for cell %p", self);
+    return;
+  }
+  
+  // Only schedule ONE delayed attempt to prevent loops
+  EAULOG(@"NSButtonCell+Eau: Scheduling single delayed attempt for button cell %p", self);
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    [self finalAttemptSetAsDefaultButton];
+  });
 }
 
 // Final attempt to set as default button (only called once)
@@ -413,97 +393,92 @@ static NSMutableSet *returnImageCells = nil;
 {
   EAULOG(@"NSButtonCell+Eau: finalAttemptSetAsDefaultButton called for button cell %p", self);
   
+  // Defensive: Verify self is still a valid object
+  if (![self isKindOfClass:[NSButtonCell class]]) {
+    EAULOG(@"NSButtonCell+Eau: Cell %p is no longer valid, aborting final attempt", self);
+    return;
+  }
+  
+  // Defensive: Check if the window still exists before proceeding
+  NSView *controlView = nil;
+  NSWindow *window = nil;
+  
+  if (![self respondsToSelector:@selector(controlView)]) {
+    EAULOG(@"NSButtonCell+Eau: Cell does not respond to controlView, aborting");
+    return;
+  }
+  
+  controlView = [self controlView];
+  if (!controlView) {
+    EAULOG(@"NSButtonCell+Eau: Control view is nil in final attempt for cell %p", self);
+    return;
+  }
+  
+  // Validate controlView is actually a view before accessing it
+  if (![controlView respondsToSelector:@selector(window)]) {
+    EAULOG(@"NSButtonCell+Eau: Control view does not respond to window selector, aborting");
+    return;
+  }
+  
+  if (![controlView isKindOfClass:[NSView class]]) {
+    EAULOG(@"NSButtonCell+Eau: Control view is not an NSView in final attempt for cell %p", self);
+    return;
+  }
+  
+  /* Getting the window can crash if view is deallocated - wrap in exception handler */
   @try {
-    // Defensive: Verify self is still a valid object
-    if (![self isKindOfClass:[NSButtonCell class]]) {
-      EAULOG(@"NSButtonCell+Eau: Cell %p is no longer valid, aborting final attempt", self);
-      return;
-    }
-    
-    // Defensive: Check if the window still exists before proceeding
-    NSView *controlView = nil;
-    NSWindow *window = nil;
-    
-    if (![self respondsToSelector:@selector(controlView)]) {
-      EAULOG(@"NSButtonCell+Eau: Cell does not respond to controlView, aborting");
-      return;
-    }
-    
-    controlView = [self controlView];
-    if (!controlView) {
-      EAULOG(@"NSButtonCell+Eau: Control view is nil in final attempt for cell %p", self);
-      return;
-    }
-    
-    // Validate controlView is actually a view before accessing it
-    if (![controlView respondsToSelector:@selector(window)]) {
-      EAULOG(@"NSButtonCell+Eau: Control view does not respond to window selector, aborting");
-      return;
-    }
-    
-    if (![controlView isKindOfClass:[NSView class]]) {
-      EAULOG(@"NSButtonCell+Eau: Control view is not an NSView in final attempt for cell %p", self);
-      return;
-    }
-    
-    /* Getting the window can crash if view is deallocated - wrap in exception handler */
-    @try {
-      window = [controlView window];
-    } @catch (NSException *windowException) {
-      EAULOG(@"NSButtonCell+Eau: Exception getting window from control view for cell %p: %@", self, windowException);
-      return;
-    }
-    
-    if (!window) {
-      EAULOG(@"NSButtonCell+Eau: Window is nil in final attempt for cell %p (window closed or view detached)", self);
-      return;
-    }
-    
-    if (![window isKindOfClass:[NSWindow class]]) {
-      EAULOG(@"NSButtonCell+Eau: Window is not an NSWindow in final attempt for cell %p", self);
-      return;
-    }
-    
-    // Check if window is still visible - if not, it's being closed
-    BOOL isVisible = NO;
-    @try {
-      isVisible = [window isVisible];
-    } @catch (NSException *visException) {
-      EAULOG(@"NSButtonCell+Eau: Exception checking window visibility for cell %p: %@", self, visException);
-      return;
-    }
-    
-    if (!isVisible) {
-      EAULOG(@"NSButtonCell+Eau: Window is not visible in final attempt for cell %p, aborting", self);
-      return;
-    }
-    
-    // Check if already processed
-    @synchronized(defaultButtonSetCells) {
-      NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
-      if ([defaultButtonSetCells containsObject:cellPtr]) {
-        EAULOG(@"NSButtonCell+Eau: Button cell %p already processed in final attempt", self);
-        return;
-      }
-    }
-    
-    // Try one more time with direct access
-    if ([self tryDirectWindowAccess]) {
-      EAULOG(@"NSButtonCell+Eau: Final direct window access succeeded for button cell %p", self);
-      return;
-    }
-    
-    // Try one more time with window search
-    if ([self trySearchAllWindows]) {
-      EAULOG(@"NSButtonCell+Eau: Final window search succeeded for button cell %p", self);
-      return;
-    }
-    
-    EAULOG(@"NSButtonCell+Eau: Final attempt failed for button cell %p - giving up", self);
+    window = [controlView window];
+  } @catch (NSException *windowException) {
+    EAULOG(@"NSButtonCell+Eau: Exception getting window from control view for cell %p: %@", self, windowException);
+    return;
   }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in finalAttemptSetAsDefaultButton for cell %p: %@", self, exception);
+  
+  if (!window) {
+    EAULOG(@"NSButtonCell+Eau: Window is nil in final attempt for cell %p (window closed or view detached)", self);
+    return;
   }
+  
+  if (![window isKindOfClass:[NSWindow class]]) {
+    EAULOG(@"NSButtonCell+Eau: Window is not an NSWindow in final attempt for cell %p", self);
+    return;
+  }
+  
+  // Check if window is still visible - if not, it's being closed
+  BOOL isVisible = NO;
+  @try {
+    isVisible = [window isVisible];
+  } @catch (NSException *visException) {
+    EAULOG(@"NSButtonCell+Eau: Exception checking window visibility for cell %p: %@", self, visException);
+    return;
+  }
+  
+  if (!isVisible) {
+    EAULOG(@"NSButtonCell+Eau: Window is not visible in final attempt for cell %p, aborting", self);
+    return;
+  }
+  
+  // Check if already processed
+  @synchronized(defaultButtonSetCells) {
+    NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
+    if ([defaultButtonSetCells containsObject:cellPtr]) {
+      EAULOG(@"NSButtonCell+Eau: Button cell %p already processed in final attempt", self);
+      return;
+    }
+  }
+  
+  // Try one more time with direct access
+  if ([self tryDirectWindowAccess]) {
+    EAULOG(@"NSButtonCell+Eau: Final direct window access succeeded for button cell %p", self);
+    return;
+  }
+  
+  // Try one more time with window search
+  if ([self trySearchAllWindows]) {
+    EAULOG(@"NSButtonCell+Eau: Final window search succeeded for button cell %p", self);
+    return;
+  }
+  
+  EAULOG(@"NSButtonCell+Eau: Final attempt failed for button cell %p - giving up", self);
 }
 
 // When highlighted, if this cell has a return icon image set internally, compute
@@ -538,80 +513,67 @@ static NSMutableSet *returnImageCells = nil;
 {
   EAULOG(@"NSButtonCell+Eau: tryDirectWindowAccess called for button cell %p", self);
   
-  @try {
-    NSView *controlView = nil;
-    if ([self respondsToSelector:@selector(controlView)]) {
-      controlView = [self controlView];
-      EAULOG(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
-    }
+  NSView *controlView = nil;
+  if ([self respondsToSelector:@selector(controlView)]) {
+    controlView = [self controlView];
+    EAULOG(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
+  }
+  
+  // Defensive: Check if controlView is still valid (not deallocated)
+  if (!controlView || ![controlView isKindOfClass:[NSView class]]) {
+    EAULOG(@"NSButtonCell+Eau: Control view is nil or invalid for button cell %p", self);
+    return NO;
+  }
+  
+  NSWindow *window = nil;
+  
+  if (controlView) {
+    window = [controlView window];
+    EAULOG(@"NSButtonCell+Eau: Found window %p for control view %p", window, controlView);
+  
     
-    // Defensive: Check if controlView is still valid (not deallocated)
-    if (!controlView || ![controlView isKindOfClass:[NSView class]]) {
-      EAULOG(@"NSButtonCell+Eau: Control view is nil or invalid for button cell %p", self);
-      return NO;
-    }
-    
-    NSWindow *window = nil;
-    
-    if (controlView) {
-      @try {
-        window = [controlView window];
-        EAULOG(@"NSButtonCell+Eau: Found window %p for control view %p", window, controlView);
-      }
-      @catch (NSException *windowException) {
-        EAULOG(@"NSButtonCell+Eau: ERROR getting window from control view %p: %@", controlView, windowException);
-      }
-      
-      if (!window) {
-        // Try to find window by traversing the view hierarchy
-        EAULOG(@"NSButtonCell+Eau: Traversing view hierarchy to find window for control view %p", controlView);
-        NSView *currentView = controlView;
-        while (currentView && !window) {
-          @try {
-            currentView = [currentView superview];
-            // Defensive: Check if currentView is still valid before accessing
-            if (currentView && [currentView isKindOfClass:[NSView class]]) {
-              window = [currentView window];
-              if (window) {
-                EAULOG(@"NSButtonCell+Eau: Found window %p through view hierarchy traversal", window);
-              }
-            } else {
-              // Invalid view in hierarchy, stop traversing
-              break;
+    if (!window) {
+      // Try to find window by traversing the view hierarchy
+      EAULOG(@"NSButtonCell+Eau: Traversing view hierarchy to find window for control view %p", controlView);
+      NSView *currentView = controlView;
+      while (currentView && !window) {
+        @try {
+          currentView = [currentView superview];
+          // Defensive: Check if currentView is still valid before accessing
+          if (currentView && [currentView isKindOfClass:[NSView class]]) {
+            window = [currentView window];
+            if (window) {
+              EAULOG(@"NSButtonCell+Eau: Found window %p through view hierarchy traversal", window);
             }
-          }
-          @catch (NSException *hierarchyException) {
-            EAULOG(@"NSButtonCell+Eau: ERROR traversing view hierarchy: %@", hierarchyException);
+          } else {
+            // Invalid view in hierarchy, stop traversing
             break;
           }
         }
-      }
-      
-      // Defensive: Check if window is still valid before using it
-      if (window && [window isKindOfClass:[NSWindow class]]) {
-        @try {
-          [self markAsDefaultButtonSet];
-          EAULOG(@"NSButtonCell+Eau: Setting window %p default button cell to %p", window, self);
-          [window setDefaultButtonCell:self];
-          
-          // Also make the button visually selected/highlighted
-          [self safelyMakeButtonSelectedAndHighlighted];
-          
-          EAULOG(@"NSButtonCell+Eau: Successfully set default button cell for window %p", window);
-          return YES;
+        @catch (NSException *hierarchyException) {
+          EAULOG(@"NSButtonCell+Eau: ERROR traversing view hierarchy: %@", hierarchyException);
+          break;
         }
-        @catch (NSException *setDefaultException) {
-          EAULOG(@"NSButtonCell+Eau: ERROR setting default button cell for window %p: %@", window, setDefaultException);
-        }
-      } else {
-        EAULOG(@"NSButtonCell+Eau: No window found for control view %p", controlView);
       }
-    } else {
-      EAULOG(@"NSButtonCell+Eau: No control view found for button cell %p", self);
     }
-  }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in tryDirectWindowAccess for cell %p: %@", self, exception);
+    
+    // Defensive: Check if window is still valid before using it
+    if (window && [window isKindOfClass:[NSWindow class]]) {
+      [self markAsDefaultButtonSet];
+      EAULOG(@"NSButtonCell+Eau: Setting window %p default button cell to %p", window, self);
+      [window setDefaultButtonCell:self];
+      
+      // Also make the button visually selected/highlighted
+      [self safelyMakeButtonSelectedAndHighlighted];
+      
+      EAULOG(@"NSButtonCell+Eau: Successfully set default button cell for window %p", window);
+      return YES;
+    
+    } else {
+      EAULOG(@"NSButtonCell+Eau: No window found for control view %p", controlView);
+    }
+  } else {
+    EAULOG(@"NSButtonCell+Eau: No control view found for button cell %p", self);
   }
   
   return NO;
@@ -642,21 +604,19 @@ static NSMutableSet *returnImageCells = nil;
     }
   }
 
-  // Call original implementation (swizzled)
+  // Call original implementation (swizzled). Keep this one guarded: it runs on
+  // AppKit's display path, so an exception here must not escape into the draw
+  // loop, and must not skip the imagePosition restore below (which would leave
+  // the cell stuck at NSNoImage).
   @try {
     [self EAU_drawInteriorWithFrame:cellFrame inView:controlView];
   }
   @catch (NSException *e) {
     EAULOG(@"NSButtonCell+Eau: ERROR in EAU_drawInteriorWithFrame (original): %@", e);
   }
-
   if (shouldRemoveImagePosition) {
-    @try {
-      [self setImagePosition: oldPos];
-    }
-    @catch (NSException *e) {
-      EAULOG(@"NSButtonCell+Eau: ERROR restoring imagePosition for cell %p: %@", self, e);
-    }
+    [self setImagePosition: oldPos];
+  
   }
 }
 
@@ -665,42 +625,37 @@ static NSMutableSet *returnImageCells = nil;
 {
   EAULOG(@"NSButtonCell+Eau: trySearchAllWindows called for button cell %p", self);
   
-  @try {
-    NSArray *windows = nil;
-    if ([NSApp respondsToSelector:@selector(windows)]) {
-      windows = [NSApp windows];
-      EAULOG(@"NSButtonCell+Eau: Found %lu windows to search", (unsigned long)[windows count]);
-    } else {
-      EAULOG(@"NSButtonCell+Eau: NSApp does not respond to windows selector");
-      return NO;
-    }
-    
-    for (NSWindow *candidateWindow in windows) {
-      @try {
-        EAULOG(@"NSButtonCell+Eau: Searching window %p for button cell %p", candidateWindow, self);
-        if ([self findButtonWithCellInWindow:candidateWindow]) {
-          EAULOG(@"NSButtonCell+Eau: Found button cell %p in window %p", self, candidateWindow);
-          [self markAsDefaultButtonSet];
-          [candidateWindow setDefaultButtonCell:self];
-          
-          // Also make the button visually selected/highlighted
-          [self safelyMakeButtonSelectedAndHighlighted];
-          
-          EAULOG(@"NSButtonCell+Eau: Successfully set default button cell for window %p", candidateWindow);
-          return YES;
-        }
-      }
-      @catch (NSException *windowSearchException) {
-        EAULOG(@"NSButtonCell+Eau: ERROR searching window %p: %@", candidateWindow, windowSearchException);
-        continue;
+  NSArray *windows = nil;
+  if ([NSApp respondsToSelector:@selector(windows)]) {
+    windows = [NSApp windows];
+    EAULOG(@"NSButtonCell+Eau: Found %lu windows to search", (unsigned long)[windows count]);
+  } else {
+    EAULOG(@"NSButtonCell+Eau: NSApp does not respond to windows selector");
+    return NO;
+  }
+  
+  for (NSWindow *candidateWindow in windows) {
+    @try {
+      EAULOG(@"NSButtonCell+Eau: Searching window %p for button cell %p", candidateWindow, self);
+      if ([self findButtonWithCellInWindow:candidateWindow]) {
+        EAULOG(@"NSButtonCell+Eau: Found button cell %p in window %p", self, candidateWindow);
+        [self markAsDefaultButtonSet];
+        [candidateWindow setDefaultButtonCell:self];
+        
+        // Also make the button visually selected/highlighted
+        [self safelyMakeButtonSelectedAndHighlighted];
+        
+        EAULOG(@"NSButtonCell+Eau: Successfully set default button cell for window %p", candidateWindow);
+        return YES;
       }
     }
-    
-    EAULOG(@"NSButtonCell+Eau: Button cell %p not found in any of %lu windows", self, (unsigned long)[windows count]);
+    @catch (NSException *windowSearchException) {
+      EAULOG(@"NSButtonCell+Eau: ERROR searching window %p: %@", candidateWindow, windowSearchException);
+      continue;
+    }
   }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in trySearchAllWindows for cell %p: %@", self, exception);
-  }
+  
+  EAULOG(@"NSButtonCell+Eau: Button cell %p not found in any of %lu windows", self, (unsigned long)[windows count]);
   
   return NO;
 }
@@ -708,56 +663,41 @@ static NSMutableSet *returnImageCells = nil;
 // Helper to mark this cell as having its default button set
 - (void) markAsDefaultButtonSet
 {
-  @try {
-    @synchronized(defaultButtonSetCells) {
-      NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
-      [defaultButtonSetCells addObject:cellPtr];
-      EAULOG(@"NSButtonCell+Eau: Marked button cell %p as default button set", self);
-    }
-  }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR marking button cell %p as default: %@", self, exception);
+  @synchronized(defaultButtonSetCells) {
+    NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
+    [defaultButtonSetCells addObject:cellPtr];
+    EAULOG(@"NSButtonCell+Eau: Marked button cell %p as default button set", self);
   }
 }
 
 // Recursively search for a button that has this cell
 - (BOOL) findButtonWithCellInWindow:(NSWindow *)window
 {
-  @try {
-    NSView *contentView = [window contentView];
-    if (contentView) {
-      return [self findButtonWithCellInView:contentView];
-    }
-  }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR finding button in window %p: %@", window, exception);
+  NSView *contentView = [window contentView];
+  if (contentView) {
+    return [self findButtonWithCellInView:contentView];
   }
   return NO;
 }
 
 - (BOOL) findButtonWithCellInView:(NSView *)view
 {
-  @try {
-    if ([view isKindOfClass:[NSButton class]]) {
-      NSButton *button = (NSButton*)view;
-      if ([button cell] == self) {
-        EAULOG(@"NSButtonCell+Eau: Found matching button %p for cell %p", button, self);
+  if ([view isKindOfClass:[NSButton class]]) {
+    NSButton *button = (NSButton*)view;
+    if ([button cell] == self) {
+      EAULOG(@"NSButtonCell+Eau: Found matching button %p for cell %p", button, self);
+      return YES;
+    }
+  }
+  
+  // Recursively search subviews
+  NSArray *subviews = [view subviews];
+  if (subviews) {
+    for (NSView *subview in subviews) {
+      if ([self findButtonWithCellInView:subview]) {
         return YES;
       }
     }
-    
-    // Recursively search subviews
-    NSArray *subviews = [view subviews];
-    if (subviews) {
-      for (NSView *subview in subviews) {
-        if ([self findButtonWithCellInView:subview]) {
-          return YES;
-        }
-      }
-    }
-  }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR searching view %p: %@", view, exception);
   }
   
   return NO;
@@ -768,80 +708,64 @@ static NSMutableSet *returnImageCells = nil;
 {
   EAULOG(@"NSButtonCell+Eau: safelyMakeButtonSelectedAndHighlighted called for button cell %p", self);
   
-  @try {
-    // DON'T set the cell as highlighted permanently - this interferes with pressed state detection
-    // The default button appearance will come from the pulsing animation instead
-    EAULOG(@"NSButtonCell+Eau: Skipping setHighlighted to allow proper pressed state detection");
-    
-    // DON'T set setShowsFirstResponder to avoid interfering with text field focus
-
-  }
-  @catch (NSException *cellException) {
-    EAULOG(@"NSButtonCell+Eau: ERROR setting cell %p properties: %@", self, cellException);
-  }
+  // DON'T set the cell as highlighted permanently - this interferes with pressed state detection
+  // The default button appearance will come from the pulsing animation instead
+  EAULOG(@"NSButtonCell+Eau: Skipping setHighlighted to allow proper pressed state detection");
+  
+  // DON'T set setShowsFirstResponder to avoid interfering with text field focus
     
   // Try to get the control view safely
   NSView *controlView = nil;
-  @try {
-    if ([self respondsToSelector:@selector(controlView)]) {
-      controlView = [self controlView];
-      EAULOG(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
-    } else {
-      EAULOG(@"NSButtonCell+Eau: Button cell %p does not respond to controlView selector", self);
+  if ([self respondsToSelector:@selector(controlView)]) {
+    controlView = [self controlView];
+    EAULOG(@"NSButtonCell+Eau: Found control view %p for button cell %p", controlView, self);
+  } else {
+    EAULOG(@"NSButtonCell+Eau: Button cell %p does not respond to controlView selector", self);
+  }
+  
+  if (controlView && [controlView isKindOfClass:[NSButton class]]) {
+    NSButton *button = (NSButton *)controlView;
+    EAULOG(@"NSButtonCell+Eau: Control view is NSButton %p for cell %p", button, self);
+    
+    // Make the button highlighted with crash protection but without taking focus
+    
+    // Set as key equivalent for Enter/Return key handling but don't take focus
+    EAULOG(@"NSButtonCell+Eau: Setting button %p properties for Return key handling", button);
+    
+    // Try to set as key equivalent if possible
+    if ([button respondsToSelector:@selector(setKeyEquivalent:)]) {
+      EAULOG(@"NSButtonCell+Eau: Setting button %p key equivalent to return", button);
+      [button setKeyEquivalent:@"\r"];
     }
     
-    if (controlView && [controlView isKindOfClass:[NSButton class]]) {
-      NSButton *button = (NSButton *)controlView;
-      EAULOG(@"NSButtonCell+Eau: Control view is NSButton %p for cell %p", button, self);
+    // DON'T force the button cell to be highlighted - this interferes with pressed state detection
+    // The default button appearance will come from the pulsing animation instead
+    EAULOG(@"NSButtonCell+Eau: Skipping setHighlighted to preserve pressed state detection");
+    
+    // Force the button to redraw to show changes
+    EAULOG(@"NSButtonCell+Eau: Marking button %p as needing display", button);
+    [button setNeedsDisplay:YES];
+    
+    // Make this button the first responder ONLY if the current first responder is already a button
+    NSWindow *window = [button window];
+    if (window) {
+      NSResponder *currentFirstResponder = [window firstResponder];
+      EAULOG(@"NSButtonCell+Eau: Current first responder: %p (class: %@)", currentFirstResponder, [currentFirstResponder class]);
       
-      // Make the button highlighted with crash protection but without taking focus
-      @try {
-
-        
-        // Set as key equivalent for Enter/Return key handling but don't take focus
-        EAULOG(@"NSButtonCell+Eau: Setting button %p properties for Return key handling", button);
-        
-        // Try to set as key equivalent if possible
-        if ([button respondsToSelector:@selector(setKeyEquivalent:)]) {
-          EAULOG(@"NSButtonCell+Eau: Setting button %p key equivalent to return", button);
-          [button setKeyEquivalent:@"\r"];
-        }
-        
-        // DON'T force the button cell to be highlighted - this interferes with pressed state detection
-        // The default button appearance will come from the pulsing animation instead
-        EAULOG(@"NSButtonCell+Eau: Skipping setHighlighted to preserve pressed state detection");
-        
-        // Force the button to redraw to show changes
-        EAULOG(@"NSButtonCell+Eau: Marking button %p as needing display", button);
-        [button setNeedsDisplay:YES];
-        
-        // Make this button the first responder ONLY if the current first responder is already a button
-        NSWindow *window = [button window];
-        if (window) {
-          NSResponder *currentFirstResponder = [window firstResponder];
-          EAULOG(@"NSButtonCell+Eau: Current first responder: %p (class: %@)", currentFirstResponder, [currentFirstResponder class]);
-          
-          if (currentFirstResponder && [currentFirstResponder isKindOfClass:[NSButton class]]) {
-            EAULOG(@"NSButtonCell+Eau: Current first responder is a button, making default button %p first responder", button);
-            [window makeFirstResponder:button];
-          } else {
-            EAULOG(@"NSButtonCell+Eau: Current first responder is not a button (%@), preserving focus", [currentFirstResponder class]);
-          }
-        } else {
-          EAULOG(@"NSButtonCell+Eau: No window found for button %p", button);
-        }
-        
-        EAULOG(@"NSButtonCell+Eau: Successfully configured button %p with conditional focus", button);
-      }
-      @catch (NSException *buttonException) {
-        EAULOG(@"NSButtonCell+Eau: ERROR setting button %p properties: %@", button, buttonException);
+      if (currentFirstResponder && [currentFirstResponder isKindOfClass:[NSButton class]]) {
+        EAULOG(@"NSButtonCell+Eau: Current first responder is a button, making default button %p first responder", button);
+        [window makeFirstResponder:button];
+      } else {
+        EAULOG(@"NSButtonCell+Eau: Current first responder is not a button (%@), preserving focus", [currentFirstResponder class]);
       }
     } else {
-      EAULOG(@"NSButtonCell+Eau: Control view %p is not an NSButton or is nil for cell %p", controlView, self);
+      EAULOG(@"NSButtonCell+Eau: No window found for button %p", button);
     }
-  }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in safelyMakeButtonSelectedAndHighlighted for cell %p: %@", self, exception);
+    
+    EAULOG(@"NSButtonCell+Eau: Successfully configured button %p with conditional focus", button);
+  
+  } else {
+    EAULOG(@"NSButtonCell+Eau: Control view %p is not an NSButton or is nil for cell %p", controlView, self);
   }
 }
 
@@ -850,26 +774,21 @@ static NSMutableSet *returnImageCells = nil;
 {
   EAULOG(@"NSButtonCell+Eau: dealloc called for button cell %p", self);
   
-  @try {
-    // Cancel any pending operations
-    [NSObject cancelPreviousPerformRequestsWithTarget:self];
-    
-    // Remove from tracking sets
-    @synchronized(processingCells) {
-      NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
-      [processingCells removeObject:cellPtr];
-    }
-    
-    @synchronized(defaultButtonSetCells) {
-      NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
-      [defaultButtonSetCells removeObject:cellPtr];
-    }
-    
-    EAULOG(@"NSButtonCell+Eau: Cleanup completed for button cell %p", self);
+  // Cancel any pending operations
+  [NSObject cancelPreviousPerformRequestsWithTarget:self];
+  
+  // Remove from tracking sets
+  @synchronized(processingCells) {
+    NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
+    [processingCells removeObject:cellPtr];
   }
-  @catch (NSException *exception) {
-    EAULOG(@"NSButtonCell+Eau: ERROR in dealloc for cell %p: %@", self, exception);
+  
+  @synchronized(defaultButtonSetCells) {
+    NSValue *cellPtr = [NSValue valueWithPointer:(__bridge const void *)(self)];
+    [defaultButtonSetCells removeObject:cellPtr];
   }
+  
+  EAULOG(@"NSButtonCell+Eau: Cleanup completed for button cell %p", self);
 }
 
 // Timer callback for default button pulse — called from NSButton+Eau.m swizzle


### PR DESCRIPTION
### What
Remove the `@try/@catch` blocks in `NSButtonCell+Eau.m` whose only action is a debug log. Keep the catches that perform real recovery or control flow, and keep the guard around the live `drawInteriorWithFrame:` call.

### Why
The removed catches logged via a macro that is a no-op in release builds, so they silently swallowed exceptions without recovering anything (and added noise). Removing them lets a genuine exception surface instead of being hidden. The draw-path guard is kept on purpose: an exception there must not unwind into AppKit's display loop, nor skip the image-position restore that follows.

Fixes #43
