### PR TITLE
Fix infinite recursion when setting a default button cell

### DIFF
--- a/NSButtonCell+Eau.m
+++ b/NSButtonCell+Eau.m
@@ -216,8 +216,12 @@ static NSMutableSet *returnImageCells = nil;
       if (![self isProcessingReturnButton]) {
         [self setIsProcessingReturnButton:YES];
         [self setIsDefaultButton:@YES];
-        [self setIsProcessingReturnButton:NO];
+        // Keep the guard set ACROSS enablePulsing: it re-drives setKeyEquivalent:,
+        // which routes through GSTheme back into setImage: (the return-arrow image).
+        // Clearing the flag before enablePulsing left that re-entry unguarded and
+        // produced an infinite setImage:/setKeyEquivalent: recursion (stack overflow).
         [self enablePulsing];
+        [self setIsProcessingReturnButton:NO];
       }
       
       return; // Don't set the image
@@ -284,8 +288,12 @@ static NSMutableSet *returnImageCells = nil;
       if (![self isProcessingReturnButton]) {
         [self setIsProcessingReturnButton:YES];
         [self setIsDefaultButton:@YES];
-        [self setIsProcessingReturnButton:NO];
+        // Keep the guard set ACROSS enablePulsing: it re-drives setKeyEquivalent:,
+        // which routes through GSTheme back into setImage: (the return-arrow image).
+        // Clearing the flag before enablePulsing left that re-entry unguarded and
+        // produced an infinite setImage:/setKeyEquivalent: recursion (stack overflow).
         [self enablePulsing];
+        [self setIsProcessingReturnButton:NO];
       }
       
       return; // Don't set the image


### PR DESCRIPTION
### What
Hold the re-entrancy guard flag across the call that re-drives `setKeyEquivalent:` — move the `isProcessingReturnButton` reset to *after* `enablePulsing` — matching the already-correct image getter.

### Why
Marking a button as the default re-drives `setKeyEquivalent:`, which routes back through the theme into `setImage:` and re-enters the default-button setup. The guard was cleared before that call, so the re-entry was unguarded and recursed without bound (stack overflow) whenever a default button cell was set on a button already placed in a window. Holding the guard across the call makes the re-entrant `setImage:` skip the setup and breaks the cycle.

Fixes #45
