### PR TITLE
Defer terminate from the last-window-closed handler to the runloop

### DIFF
--- a/NSApplication+Eau.m
+++ b/NSApplication+Eau.m
@@ -52,7 +52,11 @@
       if ([_delegate
         applicationShouldTerminateAfterLastWindowClosed: self])
         {
-          [self terminate: self];
+          // Defer to the top of the next runloop iteration: _lastWindowClosed
+          // runs mid-event with the runloop's autorelease pool live, and a
+          // synchronous terminate runs the whole teardown nested inside it.
+          // Scheduling it lets the current event/pool unwind cleanly first.
+          [self performSelector: @selector(terminate:) withObject: self afterDelay: 0.0];
         }
     }
   else
@@ -60,7 +64,8 @@
       // Terminate by default for all interface styles when last window closes
       // Overrides default GNUstep behavior:
       // https://github.com/gnustep/libs-gui/blob/402a94295ad56ab6219a6b18fdf9d9624834983f/Source/NSApplication.m#L4187C1-L4205C2
-      [self terminate: self];
+      // Deferred (see above) to avoid a synchronous mid-event teardown.
+      [self performSelector: @selector(terminate:) withObject: self afterDelay: 0.0];
     }
 }
 


### PR DESCRIPTION
### What
Schedule `-terminate:` on the next runloop iteration (`performSelector:withObject:afterDelay:0.0`) instead of calling it synchronously, at both call sites in the last-window-closed handler.

### Why
The handler runs mid-event with the runloop's autorelease pool live; a synchronous `terminate:` runs the entire application teardown nested inside that pool while the event is still on the stack. Deferring lets the current event and its autorelease pool unwind cleanly before teardown begins.

Fixes #46
